### PR TITLE
first pass with initial copyedits, upgrade fern version

### DIFF
--- a/fern/docs/pages/authentication-methods.mdx
+++ b/fern/docs/pages/authentication-methods.mdx
@@ -1,4 +1,4 @@
-You can pass your api_key  as url parameters using the following format:
+You can pass your api_key as a url parameter, using the following format:
 
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \

--- a/fern/docs/pages/getting-started.mdx
+++ b/fern/docs/pages/getting-started.mdx
@@ -1,10 +1,13 @@
-The documentation for the FluidStack API is available at [API Reference](/api-reference).
+For the FluidStack API documentation, view the [API Reference](/api-reference).
 
-To interact with our API, you will need an `api_key`. Please contact [support](mailto:support@fluidstack.io) to get one.
+## Requirements
 
-# Authentication Method
+ - To interact with our API, you need an `api_key`. Contact [support](mailto:support@fluidstack.io) to obtain one.
+ - To create an instance, you must provide values for `gpu_type`, `operating_system_label` and `ssh_key_id`. You can use an existing SSH key or [create a new one](#create-an-ssh-key).
 
-You can pass your `api_key`  as url parameters using the following format:
+## Authentication
+
+Pass your `api_key` as a url parameter using the following format:
 
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \
@@ -12,11 +15,7 @@ curl -H "Content-Type: application/json" \
     --request GET 'https://platform.fluidstack.io/instances'
 ```
 
-# Creating an Instance
-
-To create an instance, first you need to get the `gpu_type`, `operating_system_label` and `ssh_key_id`. You can get the `ssh_key_id` by creating a new SSH key or using an existing one.
-
-## Creating an SSH Key
+## Create an SSH key
 
 You can create an SSH key by using the following endpoint:
 
@@ -27,7 +26,7 @@ curl -H "Content-Type: application/json" \
     --data '{"name": "mykey", "public_key": "<public_key>"}'
 ```
 
-the endpoint will return the ssh key id
+The endpoint will return the `id`, `name`, and `public_key` of the created SSH key.
 
 ```json
 {
@@ -36,14 +35,18 @@ the endpoint will return the ssh key id
     "public_key": "<public_key>"
 }
 ```
-Alternatively, if you have an SSH Key already, you can use the following endpoint:
+
+## List existing SSH keys
+
+The following endpoint returns a list of SSH keys:
+
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \
      -H "api-key: <api_key>" \
     --request GET 'https://platform.fluidstack.io/ssh_keys'
 ```
-which will return a list of ssh keys and their ids
 
+Each object in the list represents an SSH key, including its `id`, `name`, and `public_key`. 
 
 ```json
 [
@@ -54,20 +57,15 @@ which will return a list of ssh keys and their ids
     }
     ...
 ]
-
 ```
-
-
 
 ## Create the instance 
 
-You can create an instance by using the following endpoint. Replace `<ssh_key_id>` with the value you got from the previous steps. We will use `RTX_A6000_48GB` GPU instance type with exactly 1 GPU. 
-We will also use the `ubuntu_20_04_lts` operating system template. 
+Use the cURL command below to create a new endpoint. Replace `<ssh_key_id>` with the value you received from the previous steps. We will use `RTX_A6000_48GB` GPU instance type with exactly 1 GPU. We will also use the `ubuntu_20_04_lts` operating system template. 
 
-You can get the list of available operating systems and GPUs by using the [list_available_configurations](/api-reference/ist-available-configurations-list-available-configurations-get) and [list_available_os_templates](/api-reference/list_available_os_templates-list_available_os_templates-get) endpoints. Alternatively
-a walkthrough is provided [here](/list-of-available-configurations-and-operating-systems).
+You can get the list of available operating systems and GPUs by using the [list_available_configurations](/api-reference/ist-available-configurations-list-available-configurations-get) and [list_available_os_templates](/api-reference/list_available_os_templates-list_available_os_templates-get) endpoints.
 
-
+Alternatively, view [the full list of available configurations and operating systems](/list-of-available-configurations-and-operating-systems).
 
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \
@@ -76,7 +74,7 @@ curl -H "Content-Type: application/json" \
     --data '{"name": "myinstance", "operating_system_label": "ubuntu_20_04_lts", "ssh_keys": ["<ssh_key_id>"], "gpu_type": "RTX_A6000_48GB", "gpu_count": 1}'
 ```
 
-You will get a response with an instance id and the instance status will be `pending`. The status will change to `running` after the instance is created and available. 
+You will receive a response with an instance `id`. At first, the instance `status` will be `pending`. The `status` will change to `running` after the instance is created and available. 
 
 ```json
 {
@@ -98,7 +96,7 @@ You will get a response with an instance id and the instance status will be `pen
 ```
 ## Access your instance 
 
-When the instance is running, you can connect to it SSH using the following command:
+When the instance is running, you can connect to it using SSH:
 
 ```bash maxLines=0
 ssh -i <private_key> -p <ssh_port> <username>@<ip_address>

--- a/fern/docs/pages/home.mdx
+++ b/fern/docs/pages/home.mdx
@@ -16,7 +16,7 @@ subtitle: Your guide to using the FluidStack API
         icon="fa-regular fa-book" 
         href="/programmatic-instance-management"
     >
-        Examples of how to use the FluidStack API in Python.
+        Examples of how to use the FluidStack API in Python
     </Card>
     <Card 
         title="API Reference" 

--- a/fern/docs/pages/list-available.mdx
+++ b/fern/docs/pages/list-available.mdx
@@ -3,7 +3,7 @@ A configuration consists of the specific GPU, CPU, and storage settings for an i
 
 ## Get the list of available configurations
 
-Get the up-to-date list of all available configurations from the [`GET /list_available_configurations](https://docs.fluidstack.io/api-reference/configurations/list) endpoint.
+Get the up-to-date list of all available configurations from the [`GET /list_available_configurations`](/api-reference/configurations/list) endpoint.
 
 For example, you can use cURL to call the endpoint:
 
@@ -37,7 +37,7 @@ Use `gpu_model.name` as `<gpu_type>` and `<gpu_count>` to select the configurati
 
 ## Get the list of available operating systems
 
-Get the up-to-date list of all available operating systems from the [`GET /list_available_os_templates](https://docs.fluidstack.io/api-reference/templates/list) endpoint.
+Get the up-to-date list of all available operating systems from the [`GET /list_available_os_templates`](/api-reference/templates/list) endpoint.
 
 For example, you can use cURL to call the endpoint:
 

--- a/fern/docs/pages/list-available.mdx
+++ b/fern/docs/pages/list-available.mdx
@@ -1,20 +1,19 @@
 ## Configurations
-A configuration is a type of instance, showing the type of GPU, CPU, and storage.
+A configuration consists of the specific GPU, CPU, and storage settings for an instance.
 
-## Operating system
-An operating system is the software that runs on the instance.
+## Get the list of available configurations
 
-## Getting the list of available configurations
+Get the up-to-date list of all available configurations from the [`GET /list_available_configurations](https://docs.fluidstack.io/api-reference/configurations/list) endpoint.
 
-You can get the list of available configurations by using the following endpoint:
+For example, you can use cURL to call the endpoint:
 
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \
      -H "api-key: <api_key>" \
     --request GET 'https://platform.fluidstack.io/list_available_configurations'
 ```
-which will return a list of configurations
 
+Expected output:
 ```json
 [
   {
@@ -33,18 +32,22 @@ which will return a list of configurations
   ...
 ]
 ```
-use `gpu_model.name` as `<gpu_type>` and `<gpu_count>` to select the configuration you want to use.
 
-## Getting the list of available operating systems
+Use `gpu_model.name` as `<gpu_type>` and `<gpu_count>` to select the configuration you want to use.
 
-You can get the list of available operating systems by using the following endpoint:
+## Get the list of available operating systems
+
+Get the up-to-date list of all available operating systems from the [`GET /list_available_os_templates](https://docs.fluidstack.io/api-reference/templates/list) endpoint.
+
+For example, you can use cURL to call the endpoint:
 
 ```bash maxLines=0
 curl -H "Content-Type: application/json" \
      -H "api-key: <api_key>" \
     --request GET 'https://platform.fluidstack.io/list_available_os_templates'
 ```
-which will return a list of operating system templates
+
+Expected output:
 
 ```json
 [
@@ -58,10 +61,7 @@ which will return a list of operating system templates
 ]
 ```
 
-# List of available configurations
-
-
-
+## List of available configurations
 
 <div style="background-color: white; border-radius: 4px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); overflow: hidden;">
   <table style="width: 100%; border-collapse: collapse;">

--- a/fern/docs/pages/programmatic-instance-management.mdx
+++ b/fern/docs/pages/programmatic-instance-management.mdx
@@ -1,14 +1,14 @@
 ## Script Steps
  
-1. **Create an SSH key**: If no SSH keys exist, it reads the public key from the default location (`~/.ssh/id_rsa.pub`) and sends a POST request to the same endpoint to create a new SSH key.
+1. **Create an SSH key**: If no SSH key exists, the script reads the public key from the default location (`~/.ssh/id_rsa.pub`) and sends a POST request to create a new SSH key.
 
-2. **Launch Instance**: Launche instances, specifying SSH keys, GPU Type, GPU count, and OS.
+2. **Create an instance**: Create an instance, specifying the API and SSH keys, GPU Type, GPU count, and OS.
 
-3. **Check instance Status**: Check the status of the created instance until they are running.
+3. **Check instance status**: Check the status of the created instance until it is running.
 
-4. **Printing instance Details**: Once the instance is running, the script prints the instance IP.
+4. **Print instance details**: Once the instance is running, the script prints the instance IP.
 
-5. **Deleting instance**: Finally, delete the created instance.
+5. **Delete instance**: Finally, delete the created instance.
 
 ## Script 
 
@@ -29,8 +29,8 @@ headers = {
     "api-key": api_key
 }
 
-# Create SSH Key
-print("Creating SSH Key")
+# 1. Create SSH Key
+print("Creating SSH key")
 public_key = open(os.path.join(Path.home(), ".ssh", "id_rsa.pub")).read().strip() # Read the public key from the home directory
 r = requests.post(
     url + "ssh_keys",
@@ -38,16 +38,16 @@ r = requests.post(
     json={"name": "my_key", "public_key": public_key}, # Create a new SSH key with the name "my_key" and the public key from the home directory
 )
 if not r.ok:
-    raise Exception("Could not create ssh key")
+    raise Exception("Could not create SSH key")
 
 ssh_key_ids = [r.json()["id"]]
 
 gpu_type = "RTX_A6000_48GB"
 gpu_count = 4
-operating_system_label ='ubuntu_20_04_lts'
+operating_system_label = 'ubuntu_20_04_lts'
 
-# create an instance 
-print("Creating Instance")
+# Create an instance 
+print("Creating instance")
 r = requests.post(
     url + "instances",
     headers=headers,
@@ -89,7 +89,6 @@ while instance_status != "running":
     time.sleep(10)
 
 # Instance is running
-
 print("Instance IP address: " + instance['public_ip'])
 
 # Delete instance
@@ -98,6 +97,6 @@ r = requests.delete(url + f"instances/{instance_id}", headers=headers)
 if not r.ok:
     print(r.json())
     raise Exception("Could not delete instance")
-print("Instance Deleted")
+print("Instance deleted")
 
 ```

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "FluidStack",
-  "version": "0.26.3"
+  "version": "0.30.3"
 }


### PR DESCRIPTION
- Quick first pass with focus on copyedits (fix typos, make capitalization consistent, improve wording, remove any h1-level headings as Fern already sets an h1 and only one should be used per page, etc)
- Update to latest Fern version