### PR TITLE
use fern components, add openapi examples and server

### DIFF
--- a/fern/docs/pages/getting-started.mdx
+++ b/fern/docs/pages/getting-started.mdx
@@ -18,6 +18,8 @@ When creating an instance, you must provide an SSH key. The SSH key is used for 
 
 Existing SSH keys are listed in your [FluidStack Dashboard](https://dashboard.fluidstack.io/dashboard/ssh-keys). If there are none listed, or you want to use a new SSH key, you can create one through the Dashboard. 
 
+Alternatively, you can create an SSH key by calling the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint:
+
 You must provide a unique name for the SSH key, along with a public key. If you don't have a public key, see: [Create a public key](/).
 
 <Note>
@@ -28,13 +30,11 @@ You must provide a unique name for the SSH key, along with a public key. If you 
     - ecdsa keys with NIST curves
 </Note>
 
-Alternatively, you can create an SSH key by calling the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint:
-
 <EndpointRequestSnippet endpoint="POST /ssh_keys" />
 
-If your POST request is successful, the endpoint responds by echoing the `name` and `public_key` you sent.
+If your POST request is successful, the endpoint responds by echoing the `name` and `public_key` that you sent.
 
-```json title="JSON"
+```json title="Response"
 {
     "name": "mykey",
     "public_key": "<your_public_key>"
@@ -49,7 +49,7 @@ The following endpoint responds with a list of SSH keys:
 
 Each object in the list represents an SSH key, including its `name` and `public_key`. 
 
-```json title="JSON"
+```json title="Response"
 [
     {
         "name": "mykey",
@@ -61,11 +61,11 @@ Each object in the list represents an SSH key, including its `name` and `public_
 
 ## Create the instance 
 
-Use the cURL command below to create a new endpoint. Replace `<ssh_key_name>` with the `name` of your SSH key. 
+Use the cURL command below to create a new endpoint. Replace `<api_key>` with your API key, and `<ssh_key_name>` with the `name` of your SSH key. 
 
 The example below is configured with a `"gpu_type"` of `"RTX_A6000_48GB"`, a `"gpu_count"` of `1`, and an `"operating_system_label"` of `"ubuntu_20_04_lts"`. 
 
-To use a different configuration, view [the available configurations and operating systems](/list-of-available-configurations-and-operating-systems). 
+If you prefer, you can use a different configuration and/or operating system. [View your options.](/list-of-available-configurations-and-operating-systems)
 
 ```bash title="bash"
 curl -X POST https://platform.fluidstack.io/instances \
@@ -74,11 +74,11 @@ curl -X POST https://platform.fluidstack.io/instances \
     --d '{"name": "myinstance", "operating_system_label": "ubuntu_20_04_lts", "ssh_keys": ["<ssh_key_name>"], "gpu_type": "RTX_A6000_48GB", "gpu_count": 1}'
 ```
 
-You will receive a response with an instance `id`. 
+If your request is sent successfully, the endpoint responds with the created instance's details, including its `id` and `status`.
 
-At first, the instance `status` will be `pending`. The `status` will change to `running` after the instance is created and available. 
+Initially, the instance `status` will be `pending`. The `status` changes to `running` once the instance is created and available. 
 
-```json title="json"
+```json title="JSON response"
 {
     "id": "<instance_id>",
     "status": "pending",

--- a/fern/docs/pages/getting-started.mdx
+++ b/fern/docs/pages/getting-started.mdx
@@ -1,20 +1,16 @@
-For the FluidStack API documentation, view the [API Reference](/api-reference).
-
 ## Requirements
 
- - To interact with our API, you need an API key. Visit the [FluidStack Dashboard](https://dashboard.fluidstack.io/dashboard/api-keys) to retrieve or create an API key.
- - To create an instance, you must provide values for `gpu_type`, `operating_system_label`, and `ssh_key_name`. You can use an existing SSH key or [create one](#create-an-ssh-key).
+ - <Markdown src="../snippets/api-key.mdx" />
+ - A [public/private key pair](/authentication#public-key)
+ - To create an instance, you must provide values for `gpu_type`, `operating_system_label`, and `ssh_key_name`. 
 
 ## Authentication
 
 Whenever you make a call to the FluidStack API, include your API key in the request headers.
 
-The example below uses cURL to call the [`GET /instances`](/api-reference/instances/list) endpoint. The highlighted line demonstrates how to include your API key:
+The example below uses cURL to call the [`GET /instances`](/api-reference/instances/list) endpoint. The second line demonstrates how to include your API key in the headers:
 
-```bash title="bash" {2}
-curl https://platform.fluidstack.io/instances \
-     -H "api-key: <your_api_key>"
-```
+<EndpointRequestSnippet endpoint="GET /instances" />
 
 ## Create an SSH key
 
@@ -24,23 +20,17 @@ Existing SSH keys are listed in your [FluidStack Dashboard](https://dashboard.fl
 
 You must provide a unique name for the SSH key, along with a public key. If you don't have a public key, see: [Create a public key](/).
 
-Supported public key formats: 
-  - ssh-rsa
-  - ssh-dss (DSA)
-  - ssh-ed25519
-  - ecdsa keys with NIST curves
+<Note>
+  Supported public key formats: 
+    - ssh-rsa
+    - ssh-dss (DSA)
+    - ssh-ed25519
+    - ecdsa keys with NIST curves
+</Note>
 
 Alternatively, you can create an SSH key by calling the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint:
 
-```bash title="bash"
-curl -X POST https://platform.fluidstack.io/ssh_keys \
-     -H "api-key: <your_api_key>" \
-     -H "Content-Type: application/json" \
-     -d '{
-            "name": "name",
-            "public_key": "<your_public_key>"
-         }'
-```
+<EndpointRequestSnippet endpoint="POST /ssh_keys" />
 
 If your POST request is successful, the endpoint responds by echoing the `name` and `public_key` you sent.
 
@@ -55,10 +45,7 @@ If your POST request is successful, the endpoint responds by echoing the `name` 
 
 The following endpoint responds with a list of SSH keys:
 
-```bash title="bash"
-curl https://platform.fluidstack.io/ssh_keys \
-     -H "api-key: <api_key>"
-```
+<EndpointRequestSnippet endpoint="GET /ssh_keys" />
 
 Each object in the list represents an SSH key, including its `name` and `public_key`. 
 
@@ -78,7 +65,7 @@ Use the cURL command below to create a new endpoint. Replace `<ssh_key_name>` wi
 
 The example below is configured with a `"gpu_type"` of `"RTX_A6000_48GB"`, a `"gpu_count"` of `1`, and an `"operating_system_label"` of `"ubuntu_20_04_lts"`. 
 
-To use a different configuration, view [the available configurations and operating systems](/list-of-available-configurations-and-operating-systems). The 
+To use a different configuration, view [the available configurations and operating systems](/list-of-available-configurations-and-operating-systems). 
 
 ```bash title="bash"
 curl -X POST https://platform.fluidstack.io/instances \
@@ -87,7 +74,9 @@ curl -X POST https://platform.fluidstack.io/instances \
     --d '{"name": "myinstance", "operating_system_label": "ubuntu_20_04_lts", "ssh_keys": ["<ssh_key_name>"], "gpu_type": "RTX_A6000_48GB", "gpu_count": 1}'
 ```
 
-You will receive a response with an instance `id`. At first, the instance `status` will be `pending`. The `status` will change to `running` after the instance is created and available. 
+You will receive a response with an instance `id`. 
+
+At first, the instance `status` will be `pending`. The `status` will change to `running` after the instance is created and available. 
 
 ```json title="json"
 {
@@ -110,7 +99,7 @@ You will receive a response with an instance `id`. At first, the instance `statu
 
 ## Access your instance 
 
-When the instance is running, you can connect to it using SSH. Use the private key that corresponds to the public key you used when creating the SSH key for this instance. 
+When the instance is running, you can connect to it using SSH. Use the private key that corresponds to the public key you used when creating the SSH key for this instance.
 
 ```bash title="bash"
 ssh -i <your_private_key> -p <ssh_port> <username>@<ip_address>

--- a/fern/docs/pages/list-available.mdx
+++ b/fern/docs/pages/list-available.mdx
@@ -3,7 +3,7 @@ A configuration consists of the specific GPU, CPU, and storage settings for an i
 
 ### Get the list of available configurations
 
-For the most up-to-date list of configurations, call the [`GET /list_available_configurations`](/api-reference/configurations/list) endpoint.
+For the most up-to-date list, call the [`GET /list_available_configurations`](/api-reference/configurations/list) endpoint.
 
 Example request using cURL:
 <EndpointRequestSnippet endpoint="GET /list_available_configurations" />
@@ -44,11 +44,11 @@ Whenever you create a new instance, a value for `"gpu_type"` is required. To fin
 
 ## Operating systems
 
-FluidStack makes available a variety of operating system software for your instances.
+A variety of operating system software is available for your instances.
 
 ### Get the list of available operating systems
 
-For the most up-to-date list of operating systems, call the [`GET /list_available_os_templates`](/api-reference/templates/list) endpoint.
+For the most up-to-date list, call the [`GET /list_available_os_templates`](/api-reference/templates/list) endpoint.
 
 Example request using cURL:
 <EndpointRequestSnippet endpoint="GET /list_available_os_templates" />

--- a/fern/docs/pages/list-available.mdx
+++ b/fern/docs/pages/list-available.mdx
@@ -1,342 +1,63 @@
 ## Configurations
 A configuration consists of the specific GPU, CPU, and storage settings for an instance.
 
-## Get the list of available configurations
+### Get the list of available configurations
 
-Get the up-to-date list of all available configurations from the [`GET /list_available_configurations`](/api-reference/configurations/list) endpoint.
+For the most up-to-date list of configurations, call the [`GET /list_available_configurations`](/api-reference/configurations/list) endpoint.
 
-For example, you can use cURL to call the endpoint:
+Example request using cURL:
+<EndpointRequestSnippet endpoint="GET /list_available_configurations" />
 
-```bash title="bash"
-curl https://platform.fluidstack.io/list_available_configurations \
-     -H "api-key: <your_api_key>"
-```
+The endpoint returns a list of configuration objects, as shown in this example response:
+<EndpointResponseSnippet endpoint="GET /list_available_configurations" />
 
-Expected output:
-```json title="JSON"
-[
-  {
-    "id": "<configuration_id>",
-    "gpu_model": {
-      "name": "<gpu_type>",
-      "memory_size_mb": <memory_size_mb>
-    },
-    "cpu_model": "generic",
-    "gpu_count": <gpu_count>,
-    "cpu_count": <cpu_count>,
-    "nvme_storage_size_gb": <nvme_storage_size_gb>,
-    "memory_size_mb": <memory_size_mb>,
-    "estimated_provisioning_time_minutes": <estimated_provisioning_time_minutes>
-  },
-  ...
-]
-```
-When creating a new instance, a value for `"gpu_type"` is required. Find the available options in the values for `"gpu_model.name"` returned by this endpoint. 
+Whenever you create a new instance, a value for `"gpu_type"` is required. To find the available options, see the values for `"gpu_model.name"` returned by this endpoint. 
 
-## Get the list of available operating systems
+### List of available configurations
 
-Get the up-to-date list of all available operating systems from the [`GET /list_available_os_templates`](/api-reference/templates/list) endpoint.
+| GPU Type         | GPU Count | CPU Count | RAM Size (MB) | NVME Storage Size (GB) |
+|------------------|-----------|-----------|---------------|------------------------|
+| RTX_A6000_48GB   | 1         | 16        | 59            | 425                    |
+| RTX_A6000_48GB   | 2         | 32        | 119           | 850                    |
+| RTX_A6000_48GB   | 4         | 64        | 238           | 1700                   |
+| A100_PCIE_80GB   | 1         | 32        | 120           | 200                    |
+| A100_PCIE_80GB   | 2         | 64        | 240           | 400                    |
+| A100_PCIE_80GB   | 4         | 128       | 480           | 800                    |
+| RTX_A4000_16GB   | 1         | 6         | 24            | 160                    |
+| RTX_A4000_16GB   | 2         | 12        | 48            | 320                    |
+| RTX_A4000_16GB   | 4         | 24        | 96            | 640                    |
+| RTX_A4000_16GB   | 8         | 48        | 192           | 1280                   |
+| RTX_A4000_16GB   | 10        | 64        | 240           | 1600                   |
+| RTX_A5000_24GB   | 1         | 8         | 30            | 200                    |
+| RTX_A5000_24GB   | 2         | 16        | 60            | 400                    |
+| RTX_A5000_24GB   | 4         | 32        | 120           | 800                    |
+| RTX_A5000_24GB   | 8         | 64        | 240           | 1600                   |
+| A100_PCIE_80GB   | 4         | 126       | 480           | 3300                   |
+| A100_PCIE_80GB   | 8         | 252       | 960           | 6600                   |
+| A100_NVLINK_80GB | 8         | 252       | 960           | 6500                   |
+| A100_PCIE_80GB   | 1         | 32        | 120           | 850                    |
+| H100_PCIE_80GB   | 4         | 126       | 720           | 3200                   |
+| H100_PCIE_80GB   | 8         | 252       | 1440          | 6500                   |
+| H100_PCIE_80GB   | 1         | 32        | 180           | 750                    |
+| H100_PCIE_80GB   | 2         | 64        | 360           | 1500                   |
+| L40_48GB         | 4         | 126       | 240           | 3300                   |
 
-For example, you can use cURL to call the endpoint:
+## Operating systems
 
-```bash title="bash"
-curl https://platform.fluidstack.io/list_available_os_templates \
-     -H "api-key: <api_key>"
-```
+FluidStack makes available a variety of operating system software for your instances.
 
-Expected output:
-```json title="JSON"
-[
-    {
-        "name": "<operating_system_name>",
-        "description": "<operating_system_description>",
-        "label": "<operating_system_label>"
-    }
-    ...
-]
-```
+### Get the list of available operating systems
 
-When creating a new instance, you can optionally include a value for `"operating_system_label"`. Find the available options in the values for `"label"` returned by this endpoint.
+For the most up-to-date list of operating systems, call the [`GET /list_available_os_templates`](/api-reference/templates/list) endpoint.
 
-If you do not provide an `"operating_system_label"` value when creating an instance, `"ubuntu_20_04_lts"` is used as the default. 
+Example request using cURL:
+<EndpointRequestSnippet endpoint="GET /list_available_os_templates" />
 
-## List of available configurations
+The endpoint returns a list of operating systems, as shown in this example response:
+<EndpointResponseSnippet 
+  endpoint="GET /list_available_os_templates"
+/>
 
-<div style="background-color: white; border-radius: 4px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); overflow: hidden;">
-  <table style="width: 100%; border-collapse: collapse;">
-    <thead style="background-color: #f5f5f5;">
-      <tr>
-        <th style="padding: 8px; text-align: left; border-bottom: 1px solid #ddd;">GPU Type</th>
-        <th style="padding: 8px; text-align: left; border-bottom: 1px solid #ddd;">GPU Count</th>
-        <th style="padding: 8px; text-align: left; border-bottom: 1px solid #ddd;">CPU Count</th>
-        <th style="padding: 8px; text-align: left; border-bottom: 1px solid #ddd;">RAM Size (MB)</th>
-        <th style="padding: 8px; text-align: left; border-bottom: 1px solid #ddd;">NVME Storage Size (GB)</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A6000_48GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">16</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">59</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">425</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A6000_48GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">2</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">32</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">119</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">850</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A6000_48GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">64</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">238</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1700</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">32</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">120</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">200</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">2</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">64</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">240</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">400</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">128</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">480</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">800</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A4000_16GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">6</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">24</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">160</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A4000_16GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">2</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">12</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">48</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">320</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A4000_16GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">24</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">96</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">640</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A4000_16GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">48</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">192</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1280</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A4000_16GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">10</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">64</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">240</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1600</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A5000_24GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">30</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">200</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A5000_24GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">2</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">16</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">60</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">400</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A5000_24GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">32</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">120</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">800</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">RTX_A5000_24GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">64</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">240</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1600</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">126</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">480</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">3300</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">252</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">960</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">6600</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_NVLINK_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">252</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">960</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">6500</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">A100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">32</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">120</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">850</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">H100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">126</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">720</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">3200</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">H100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">8</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">252</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1440</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">6500</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">H100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">32</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">180</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">750</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">H100_PCIE_80GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">2</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">64</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">360</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">1500</td>
-      </tr>
-      <tr>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">L40_48GB</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">4</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">126</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">240</td>
-        <td style="padding: 8px; border-bottom: 1px solid #ddd;">3300</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-{/*
-|      gpu_type          |gpu_count|cpu_count|ram_size_mb|nvme_storage_size_gb|
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    1    |    16   |     59    |         425        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    2    |    32   |    119    |         850        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    4    |    64   |    238    |        1700        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    1    |    32   |    120    |         200        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    2    |    64   |    240    |         400        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    4    |   128   |    480    |         800        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A4000_16GB     |    1    |    6    |     24    |         160        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A4000_16GB     |    2    |    12   |     48    |         320        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A4000_16GB     |    4    |    24   |     96    |         640        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A4000_16GB     |    8    |    48   |    192    |        1280        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A4000_16GB     |    10   |    64   |    240    |        1600        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A5000_24GB     |    1    |    8    |     30    |         200        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A5000_24GB     |    2    |    16   |     60    |         400        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A5000_24GB     |    4    |    32   |    120    |         800        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A5000_24GB     |    8    |    64   |    240    |        1600        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    4    |   126   |    480    |        3300        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    8    |   252   |    960    |        6600        |
-+------------------------+---------+---------+-----------+--------------------+
-|    A100_NVLINK_80GB    |    8    |   252   |    960    |        6500        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    1    |    32   |    120    |         850        |
-+------------------------+---------+---------+-----------+--------------------+
-|     H100_PCIE_80GB     |    4    |   126   |    720    |        3200        |
-+------------------------+---------+---------+-----------+--------------------+
-|     H100_PCIE_80GB     |    8    |   252   |    1440   |        6500        |
-+------------------------+---------+---------+-----------+--------------------+
-|     H100_PCIE_80GB     |    1    |    32   |    180    |         750        |
-+------------------------+---------+---------+-----------+--------------------+
-|     H100_PCIE_80GB     |    2    |    64   |    360    |        1500        |
-+------------------------+---------+---------+-----------+--------------------+
-|        L40_48GB        |    4    |   126   |    240    |        3300        |
-+------------------------+---------+---------+-----------+--------------------+
-|        L40_48GB        |    8    |   252   |    480    |        6600        |
-+------------------------+---------+---------+-----------+--------------------+
-|        L40_48GB        |    1    |    32   |     60    |         850        |
-+------------------------+---------+---------+-----------+--------------------+
-|        L40_48GB        |    2    |    64   |    120    |        1600        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    8    |   128   |    480    |        1700        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    1    |    6    |     55    |         500        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    2    |    12   |    110    |        1000        |
-+------------------------+---------+---------+-----------+--------------------+
-|     RTX_A6000_48GB     |    4    |    24   |    220    |        2000        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    1    |    16   |    125    |         500        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    4    |    64   |    500    |        2000        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_80GB     |    8    |   128   |    1000   |        4000        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_40GB     |    1    |    14   |    112    |        1700        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_40GB     |    2    |    28   |    224    |        3400        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_40GB     |    4    |    56   |    448    |        6800        |
-+------------------------+---------+---------+-----------+--------------------+
-|     A100_PCIE_40GB     |    8    |   120   |    940    |        13600       |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    1    |    8    |   32      |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    2    |    16   |   64      |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    4    |    32   |   128     |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    8    |    64   |   256     |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    2    |    8    |   128     |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    4    |    16   |   256     |         20         |
-+------------------------+---------+---------+-----------+--------------------+
-|        A30_24GB        |    8    |    32   |   512     |         20         |
-+-----------------------------------------------------------------------------+
-```
-*/}
+Whenever you create a new instance, you can optionally include a value for `"operating_system_label"`. To find the available options, see the values for `"label"` returned by this endpoint.
+
+<Note>If you do not provide an `"operating_system_label"` value when creating an instance, `"ubuntu_20_04_lts"` is used as the default.</Note>

--- a/fern/docs/pages/programmatic-instance-management.mdx
+++ b/fern/docs/pages/programmatic-instance-management.mdx
@@ -1,14 +1,36 @@
-## Script Steps
+The [Python script on this page](#script) provides an example of how the [FluidStack API](/api-reference) can be used to manage instances programmatically.
+
+## Requirements
+  - <Markdown src="../snippets/api-key.mdx" />
+  - A [public/private key pair](/authentication#public-key)
+  - [Python 3+](https://python.org)
+
+## Summary of script steps
+
+<Steps>
+    ### Create an SSH key
+
+      The script reads the public key from the default location (`~/.ssh/id_rsa.pub`) and sends a POST request to create a new SSH key named `"my_key"`.
+
+    ### Create an instance
+
+      The script creates an instance, specifying the API and SSH keys, GPU Type, GPU count, and operating system.
+
+    ### Check the instance status
+
+      The script checks the status of the created instance until it is running.
+
+    ### Print the instance IP
+
+      Once the instance is running, the script prints the instance IP.
+
+    ### Delete the instance
+
+      Finally, the script deletes the created instance.
+</Steps>
  
-1. **Create an SSH key**: If no SSH key exists, the script reads the public key from the default location (`~/.ssh/id_rsa.pub`) and sends a POST request to create a new SSH key.
 
-2. **Create an instance**: Create an instance, specifying the API and SSH keys, GPU Type, GPU count, and OS.
-
-3. **Check instance status**: Check the status of the created instance until it is running.
-
-4. **Print instance details**: Once the instance is running, the script prints the instance IP.
-
-5. **Delete instance**: Finally, delete the created instance.
+<Tip>To run this script, make sure to replace `<your_api_key>` in line 7 with your own API key.</Tip>
 
 ## Script 
 
@@ -21,37 +43,36 @@ import time
 api_url = "https://platform.fluidstack.io/"
 api_key = "<your_api_key>"
 
-
-# Set API Key header
+# Provide the API key in a header
 headers = {
     "api-key": api_key
 }
 
-# 1. Create SSH Key
+# 1: Create an SSH key
 print("Creating SSH key")
 public_key = open(os.path.join(Path.home(), ".ssh", "id_rsa.pub")).read().strip() # Read the public key from the home directory
 r = requests.post(
     url + "ssh_keys",
     headers=headers,
-    json={"name": "my_key", "public_key": public_key}, # Create a new SSH key with the name "my_key" and the public key from the home directory
+    json={"name": "my_key", "public_key": public_key}, # Create a new SSH key with the name "my_key", using the provided public key
 )
 if not r.ok:
     raise Exception("Could not create SSH key")
 
-ssh_key_ids = [r.json()["id"]]
+ssh_key_names = [r.json()["name"]]
 
 gpu_type = "RTX_A6000_48GB"
 gpu_count = 4
 operating_system_label = 'ubuntu_20_04_lts'
 
-# Create an instance 
+# 2: Create an instance 
 print("Creating instance")
 r = requests.post(
     url + "instances",
     headers=headers,
     json={
         "name" : "myinstance",
-        "ssh_keys": [ssh_key_ids[0]],
+        "ssh_keys": [ssh_key_names[0]],
         "gpu_type": gpu_type,
         "gpu_count": gpu_count,
         "operating_system_label": operating_system_label,
@@ -64,10 +85,11 @@ r = requests.post(
 	
 instance_id = r.json()['id']
 
-# Wait for instance to start
 instance_status = "pending"
 print("Waiting for instance to start")
 
+# 3: Check the instance status
+# This while loop checks the instance status every 10 seconds and exits when the status is "running"
 while instance_status != "running":
     if instance_status in ["unhealthy"]:
         print("Could not create instance")
@@ -86,10 +108,10 @@ while instance_status != "running":
     print("\t [" + str(count) + "] Status: " + instance_status)
     time.sleep(10)
 
-# Instance is running
+# 4: Print the instance IP
 print("Instance IP address: " + instance['public_ip'])
 
-# Delete instance
+# 5: Delete the instance
 print("Deleting instance")
 r = requests.delete(url + f"instances/{instance_id}", headers=headers)
 if not r.ok:

--- a/fern/docs/snippets/api-key.mdx
+++ b/fern/docs/snippets/api-key.mdx
@@ -1,0 +1,1 @@
+You must provide an **API key** to interact with our API. Visit the [FluidStack Dashboard](https://dashboard.fluidstack.io/dashboard/api-keys) to retrieve or create one.

--- a/fern/openapi/fluidstack-openapi.json
+++ b/fern/openapi/fluidstack-openapi.json
@@ -4,6 +4,12 @@
     "title": "Fluidstack API Service",
     "version": "0.1.0"
   },
+  "servers": [
+    {
+      "url": "https://platform.fluidstack.io",
+      "description": "Production server"
+    }
+  ],
   "paths": {
     "/healthcheck": {
       "get": {
@@ -57,7 +63,8 @@
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Api-Key"
+              "title": "Api-Key",
+              "example": "your-api-key"
             }
           },
           {
@@ -463,7 +470,34 @@
                     "$ref": "#/components/schemas/ConfigurationResponse"
                   },
                   "title": "Response List Available Configurations List Available Configurations Get"
-                }
+                },
+                "example": [
+                  {
+                    "id": "c-bd6a5e05-a3fd-4642-a82b-9da5fa784401",
+                    "gpu_model": {
+                      "name": "RTX_A6000_48GB", "memory_size_mb": 48
+                    },
+                    "cpu_model": "generic",
+                    "gpu_count": 1,
+                    "cpu_count":16,
+                    "nvme_storage_size_gb": 425,
+                    "memory_size_mb": 59.0,
+                    "estimated_provisioning_time_minutes": 0
+                  },
+                  {
+                    "id":"c-31078703-a4b2-4bfb-803c-abf887378e31",
+                    "gpu_model": {
+                      "name": "RTX_A6000_48GB",
+                      "memory_size_mb": 48
+                    },
+                    "cpu_model": "generic",
+                    "gpu_count": 1,
+                    "cpu_count": 16,
+                    "nvme_storage_size_gb": 425,
+                    "memory_size_mb": 59.0,
+                    "estimated_provisioning_time_minutes": 0
+                  }
+                ]
               }
             }
           },
@@ -526,7 +560,19 @@
                     "$ref": "#/components/schemas/OperatingSystemResponse"
                   },
                   "title": "Response List Available Os Templates List Available Os Templates Get"
-                }
+                },
+                "example": [
+                  {
+                    "name": "Ubuntu 22.04 LTS",
+                    "description": "Ubuntu 22.04 LTS plain",
+                    "label": "ubuntu_22_04_lts"
+                  },
+                  {
+                    "name": "Ubuntu 20.04 LTS",
+                    "description": "Ubuntu 20.04 LTS plain",
+                    "label": "ubuntu_20_04_lts"
+                  }
+                ]
               }
             }
           },


### PR DESCRIPTION
- Add a reuseable snippet about how to obtain an API key, update two files to use it
- Update request/response snippets in Markdown to use the EndpointRequestSnippet and EndpointResponseSnippet components
- Convert HTML table to Markdown
- Add Callout components where appropriate
- Use Steps component in Programmatic Instance Management page
- Add requirements for Python script
- Update Python script to use ssh_key_names instead of ssh_key_ids
- Add production server URL to OpenAPI definition 
- Add examples for ConfigurationResponse and OperatingSystemResponse in OpenAPI definition

