### PR TITLE
misc fixes & add openapi examples

### DIFF
--- a/fern/openapi/fluidstack-openapi.json
+++ b/fern/openapi/fluidstack-openapi.json
@@ -116,7 +116,7 @@
       },
       "post": {
         "summary": "Create a new instance",
-        "description": "This endpoint is used to create a new instance. You must provide a name, gpu_type and a list of ssh_key ids. The default GPU count is 1.",
+        "description": "This endpoint is used to create a new instance. You must provide a name for the instance, the gpu_type, and a list of SSH key names.\n\nIf you do not provide values for gpu_count and operating_system_label when calling this endpoint, the default values of 1 and 'ubuntu_20_04_lts' are used respectively.",
         "operationId": "create_instance_instances_post",
         "parameters": [
           {
@@ -388,7 +388,7 @@
           {
             "name": "api-key",
             "in": "header",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string",
               "title": "Api-Key"
@@ -443,7 +443,7 @@
       },
       "post": {
         "summary": "Create an SSH key",
-        "description": "Create a new SSH Key for the authenticated user. A unique name must be provided for the SSH key and a public key. The public key must be a valid SSH key with supported formats ssh-rsa, ssh-dss (DSA), ssh-ed25519 and ecdsa keys with NIST curves.",
+        "description": "Create a new SSH key for the authenticated user.\n\nYou must provide a unique name for the SSH key, along with a public key. The public key you provide will be duplicated on your FluidStack account for use as as an SSH key.\n\n<Note>Supported public key formats: ssh-rsa, ssh-dss (DSA), ssh-ed25519, ecdsa keys with NIST curves</Note>",
         "operationId": "create_ssh_key_ssh_keys_post",
         "parameters": [
           {
@@ -521,7 +521,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Ssh Key name"
+              "title": "Ssh Key name",
+              "example": "my_key"
             }
           },
           {
@@ -615,7 +616,7 @@
                     },
                     "cpu_model": "generic",
                     "gpu_count": 1,
-                    "cpu_count":16,
+                    "cpu_count": 16,
                     "nvme_storage_size_gb": 425,
                     "memory_size_mb": 59.0,
                     "estimated_provisioning_time_minutes": 0
@@ -741,18 +742,14 @@
       "ConfigurationResponse": {
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/ConfigId"
           },
           "gpu_model": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GPUModelResponse"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GPUModelResponse" },
+              { "type": "null" }
             ],
-            "description": "The GPU model of the configuration."
+            "description": "The GPU model of the configuration"
           },
           "cpu_model": {
             "anyOf": [
@@ -764,34 +761,42 @@
               }
             ],
             "title": "Cpu Model",
-            "description": "The CPU model of the configuration.",
+            "description": "The CPU model of the configuration",
             "default": "generic"
           },
           "gpu_count": {
             "type": "integer",
             "title": "Gpu Count",
-            "description": "The number of GPUs in the configuration."
+            "description": "The number of GPUs in the configuration"
           },
           "cpu_count": {
             "type": "integer",
             "title": "Cpu Count",
-            "description": "The number of CPUs in the configuration."
+            "description": "The number of CPUs in the configuration"
           },
           "nvme_storage_size_gb": {
             "type": "integer",
             "title": "Nvme Storage Size Gb",
-            "description": "The size of NVMe in the configuration."
+            "description": "The size of NVMe in the configuration"
           },
           "memory_size_mb": {
             "type": "number",
             "title": "Memory Size Mb",
-            "description": "The amount of RAM memory in the configuration."
+            "description": "The amount of RAM memory in the configuration"
           },
           "estimated_provisioning_time_minutes": {
             "type": "integer",
             "title": "Estimated Provisioning Time Minutes",
             "default": 0
           }
+        },
+        "example": {
+          "cpu_model": "generic",
+          "gpu_count": 1,
+          "cpu_count": 6,
+          "nvme_storage_size_gb": 160,
+          "memory_size_mb": 24.0,
+          "estimated_provisioning_time_minutes": 0
         },
         "type": "object",
         "required": [
@@ -809,7 +814,7 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "A custom name of the instance."
+            "description": "The name of the instance"
           },
           "gpu_type": {
             "$ref": "#/components/schemas/GPUType"
@@ -817,7 +822,7 @@
           "gpu_count": {
             "type": "integer",
             "title": "Gpu Count",
-            "description": "The number of GPUs to attach to the instance.",
+            "description": "The number of GPUs to attach to the instance",
             "default": 1
           },
           "ssh_keys": {
@@ -827,7 +832,7 @@
             "type": "array",
             "minItems": 1,
             "title": "Ssh Keys",
-            "description": "The list of SSH key IDs to add to the instance. These SSH keys will be used to connect to the instance."
+            "description": "The list of SSH key names to add to the instance\n\nThese SSH keys are used to connect to the instance."
           },
           "operating_system_label": {
             "allOf": [
@@ -835,8 +840,7 @@
                 "$ref": "#/components/schemas/SupportedOperatingSystem"
               }
             ],
-            "description": "The operating system label to be used to create the instance.",
-            "default": "ubuntu_20_04_lts"
+            "description": "The operating system label to be used to create the instance",
           }
         },
         "type": "object",
@@ -864,6 +868,10 @@
             "$ref": "#/components/schemas/SupportedOperatingSystem"
           }
         },
+        "example": {
+          "id": "i-ac1356f2-2833-460d-95e1-2a5ce512345",
+          "name": "my_instance1"
+        },
         "type": "object",
         "required": [
           "id",
@@ -878,12 +886,12 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "The name of the SSH key."
+            "description": "The name of the SSH key"
           },
           "public_key": {
             "type": "string",
             "title": "Public Key",
-            "description": "The public key of the SSH key."
+            "description": "The public key of the SSH key"
           }
         },
         "example": {
@@ -897,16 +905,17 @@
         ],
         "title": "CreateSSHKeyRequest"
       },
-      "EntityId": {
+      "ConfigId": {
         "type": "string",
-        "title": "EntityId"
+        "title": "ConfigId",
+        "example": "c-36ba4b56-fd30-4fc1-bb90-7c9493bab123"
       },
       "GPUModelResponse": {
         "properties": {
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "The FluidStack unique name of the GPU model."
+            "description": "The FluidStack name of the GPU model"
           },
           "memory_size_mb": {
             "anyOf": [
@@ -918,8 +927,12 @@
               }
             ],
             "title": "Memory Size Mb",
-            "description": "Memory capacity of the GPU in megabytes."
+            "description": "Memory capacity of the GPU in megabytes"
           }
+        },
+        "example": {
+          "name": "RTX_A4000_16GB",
+          "memory_size_mb": 16
         },
         "type": "object",
         "required": [
@@ -994,7 +1007,7 @@
           "id": {
             "type": "string",
             "title": "Id",
-            "description": "The unique identifier of the instance."
+            "description": "The unique identifier of the instance"
           },
           "status": {
             "allOf": [
@@ -1002,7 +1015,7 @@
                 "$ref": "#/components/schemas/InstanceStatus"
               }
             ],
-            "description": "The current status of the instance.",
+            "description": "The current status of the instance",
             "default": "pending"
           },
           "username": {
@@ -1015,7 +1028,7 @@
               }
             ],
             "title": "Username",
-            "description": "The username to be used to connect to the instance. For instance, to connect to the instance via SSH use; \"ssh <username>@<ip_address> -p <ssh_port>\".",
+            "description": "The username used to connect to the instance\n\nFor example, to connect to the instance via SSH, use; \"ssh <username>@<ip_address> -p <ssh_port>\".",
             "default": "fsuser"
           },
           "ssh_port": {
@@ -1028,7 +1041,7 @@
               }
             ],
             "title": "Ssh Port",
-            "description": "The SSH port to be used to connect to the instance.",
+            "description": "The SSH port used to connect to the instance",
             "default": "22"
           },
           "ssh_keys": {
@@ -1044,7 +1057,7 @@
               }
             ],
             "title": "Ssh Keys",
-            "description": "This is the list of the SSH keys of the instance with which you can login.",
+            "description": "A list of the SSH key names that can be used for logging into the instance with an SSH client",
             "default": []
           },
           "ip_address": {
@@ -1057,7 +1070,7 @@
               }
             ],
             "title": "Ip Address",
-            "description": "The IP address of the instance."
+            "description": "The IP address of the instance"
           },
           "name": {
             "anyOf": [
@@ -1069,7 +1082,7 @@
               }
             ],
             "title": "Name",
-            "description": "The name provided when the instance was created."
+            "description": "The name provided when the instance was created"
           },
           "current_rate": {
             "anyOf": [
@@ -1081,7 +1094,7 @@
               }
             ],
             "title": "Current Rate",
-            "description": "The current hourly price of the instance per processor based on its current status."
+            "description": "The current hourly price of the instance per processor based on its current status"
           },
           "configuration": {
             "anyOf": [
@@ -1092,7 +1105,7 @@
                 "type": "null"
               }
             ],
-            "description": "The configuration used to create the instance."
+            "description": "The configuration used to create the instance"
           },
           "created_at": {
             "anyOf": [
@@ -1105,8 +1118,17 @@
               }
             ],
             "title": "Created At",
-            "description": "The creation date and time of the instance."
+            "description": "The creation date and time of the instance"
           }
+        },
+        "example": {
+          "id": "i-8f0af088-282e-4fcb-8090-c57a71f1f111",
+          "username": "fsuser",
+          "ssh_port": "22",
+          "ssh_keys": ["my_key1", "my_key2"],
+          "ip_address": "192.0.2.0",
+          "name": "my_instance1",
+          "current_rate": 0.64
         },
         "type": "object",
         "required": [
@@ -1133,7 +1155,7 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "The friendly name of the operating system."
+            "description": "The friendly name of the operating system"
           },
           "description": {
             "anyOf": [
@@ -1145,7 +1167,7 @@
               }
             ],
             "title": "Description",
-            "description": "The description of the operating system detailing the list of pre-installed packages and customisations, if any."
+            "description": "A description of the operating system, detailing the list of pre-installed packages and customizations, if any"
           },
           "label": {
             "allOf": [
@@ -1153,7 +1175,7 @@
                 "$ref": "#/components/schemas/SupportedOperatingSystem"
               }
             ],
-            "description": "The unique slug identifier of the operating system."
+            "description": "The unique slug identifier of the operating system"
           }
         },
         "type": "object",
@@ -1165,18 +1187,10 @@
       },
       "SSHKeyResponse": {
         "properties": {
-          "id": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EntityId"
-              }
-            ],
-            "description": "The ID of the SSH key."
-          },
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "The name of the SSH key."
+            "description": "The name of the SSH key"
           },
           "public_key": {
             "anyOf": [
@@ -1188,13 +1202,17 @@
               }
             ],
             "title": "Public Key",
-            "description": "The public key."
+            "description": "The public key",
           }
+        },
+        "example": {
+          "name": "my_key",
+          "public_key": "<public_key>"
         },
         "type": "object",
         "required": [
-          "id",
-          "name"
+          "name",
+          "public_key"
         ],
         "title": "SSHKeyResponse"
       },
@@ -1206,7 +1224,9 @@
           "ubuntu_20_04_lts_nvidia",
           "ubuntu_22_04_lts_nvidia"
         ],
-        "title": "SupportedOperatingSystem"
+        "title": "SupportedOperatingSystem",
+        "example": "ubuntu_20_04_lts",
+        "default": "ubuntu_20_04_lts"
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
- replace references to SSH key id with SSH key name
- make ending punctuation consistent: only use periods for complete sentences
- add info about default values
- add openapi examples that show up in api reference
- rename EntityId to ConfigId; less confusing