### PR TITLE
fix x-fern-sdk-method-name for stop/start

### DIFF
--- a/fern/openapi/openapi-overrides.yml
+++ b/fern/openapi/openapi-overrides.yml
@@ -31,11 +31,11 @@ paths:
   /instances/{instance_id}/stop:
     put:
       x-fern-sdk-group-name: instances
-      x-fern-sdk-method-name: put
+      x-fern-sdk-method-name: stop
   /instances/{instance_id}/start:
     put:
       x-fern-sdk-group-name: instances
-      x-fern-sdk-method-name: put
+      x-fern-sdk-method-name: start
   /ssh_keys:
     get:
       x-fern-sdk-group-name: ssh_keys


### PR DESCRIPTION
affects:
- the generated API reference, which was not showing the stop endpoint due to two endpoints having the same method name
- the generated SDK - now the method names should be correct - `client.instances.start()` and `client.instances.stop()` instead of `client.instances.put()` for both