### PR TITLE
updates to authentication page

### DIFF
--- a/fern/docs/pages/authentication.mdx
+++ b/fern/docs/pages/authentication.mdx
@@ -23,37 +23,27 @@ Example:
 
 ## SSH keys
 
-The SSH (Secure SHell) protocol is used for command-line access to a running instance. It uses public-key cryptography for authentication.
+An **SSH key** is required to create an instance, and to log into an instance remotely using the SSH (Secure Shell) protocol. 
 
-Access requires a public/private key pair. You must [generate a key pair locally](https://www.ssh.com/academy/ssh/keygen), then use its public key to create an SSH key on your FluidStack account. In this context, _creating an SSH key_ means _storing a copy of a public key on your FluidStack account_. The stored SSH key is identical to your public key.
+Instead of a login password, FluidStack requires [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) for authentication. This means that you must have a public/private key pair for encryption.
+
+### Create an SSH key
+
+If you do not already have a public/private key pair, you must [generate one locally](/get-started#create-a-publicprivate-key-pair), then use its public key to [create an SSH key on your FluidStack account](/get-started#create-a-ssh-key-on-your-fluidstack-account). In this context, _creating an SSH key_ means _storing a copy of a public key on your FluidStack account_. The stored SSH key is identical to the public key.
 
 <Markdown src="../snippets/public-key-formats.mdx" />
 
-You can create an SSH key from the FluidStack Dashboard, or with the FluidStack API.
-
-### Create an SSH key from the FluidStack Dashboard
-
-1. Open the [SSH Keys page on the FluidStack Dashboard](https://dashboard.fluidstack.io/dashboard/ssh-keys).
-2. Select **Add SSH key** from the top right corner.
-3. In the popup form's **Name** field, input a unique name for this SSH key. 
-4. Paste your public key in the field labeled **Public SSH key**. Click **Confirm**.
-
-### Create an SSH key using the FluidStack API
-
-You can create an SSH key on your FluidStack account by using the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint. You can call this endpoint programmatically, or by using a command-line tool such as [cURL](https://curl.se/):
-
-<EndpointRequestSnippet endpoint="POST /ssh_keys" />
-
-If your POST request is successful, the endpoint responds with a JSON object that echoes the `name` and `public_key` that you sent.
-
-```json title="Response example"
-{
-    "name": "mykey",
-    "public_key": "<your_public_key>"
-}
-```
-
 ### Use your SSH key
 
-Whenever you create a new instance, you must provide one or more SSH keys. Once the instance is running, use the SSH key to authenticate when connecting to the instance via an SSH client.
+Whenever you create a new instance, you must provide one or more SSH keys. If more than one person will need remote access to the instance, provide a different SSH key for each person.
 
+Once the instance is running, use your private key to authenticate when connecting to the instance. The private key should correspond to a public key that you used for one of the SSH keys associated with that instance.
+
+```bash title="Connect to your instance with SSH"
+ssh -i <path_to_your_private_key> <username>@<ip_address>
+```
+
+Example:
+```bash 
+ssh -i ~/.ssh/id_rsa ubuntu@192.0.2.0
+```

--- a/fern/docs/pages/get-started.mdx
+++ b/fern/docs/pages/get-started.mdx
@@ -25,7 +25,7 @@ On this page, you will learn to do the following:
 
 You can skip this step if you already have a public/private key pair that uses a supported format from the list above.
 
-FluidStack grants you command-line access to your instances via [SSH](https://en.wikipedia.org/wiki/Secure_Shell), using [public-key cryptography](https://www.ssh.com/academy/ssh/public-key-authentication) instead of a login password for greater security. This means that you must locally generate a public/private key pair, then store your public key on your instances. You can then use your private key to access the instances.
+FluidStack grants you command-line access to your instances via [SSH](https://en.wikipedia.org/wiki/Secure_Shell), using [public-key cryptography](https://www.ssh.com/academy/ssh/public-key-authentication) instead of a login password for higher security. This means that you must locally generate a public/private key pair, then store your public key on your instances. You can then use your private key to access the instances.
 
 You can generate a public/private key pair with a command-line tool called **ssh-keygen**. This tool comes pre-installed on most operating systems.
 
@@ -86,7 +86,7 @@ cat ~/.ssh/id_ecdsa_256.pub
   With any public/private key pair that you generate, your public key can be shared freely. Your private key should be just that—private! Do not share it with others, or in public repositories such as in GitHub. 
 </Warning>
 
-### Create a SSH key on your FluidStack account
+### Create an SSH key on your FluidStack account
 
 Once you have generated a key pair locally, use its public key to create an SSH key on your FluidStack account. In this context, _creating an SSH key_ means _storing a copy of your public key on your FluidStack account_. The stored SSH key is identical to your public key.
 
@@ -184,8 +184,18 @@ When creating an instance, you must specify one or more SSH keys. You can use th
 Once the instance's status is `running`, you can connect to it using SSH. Use the private key that corresponds to the public key you used when creating the SSH key for this instance, and the `username` and `ip_address` values you noted in the previous step. 
 
 ```bash title="bash"
-ssh -i <your_private_key> <username>@<ip_address>
+ssh -i <path_to_your_private_key> <username>@<ip_address>
 ```
+
+Example:
+<CodeBlocks>
+```bash title="RSA"
+ssh -i ~/.ssh/id_rsa ubuntu@192.0.2.0
+```
+```bash title="ECDSA"
+ssh -i ~/.ssh/id_ecdsa_256 ubuntu@192.0.2.0
+```
+</CodeBlocks>
 
 <Note>The first time you connect to your instance, you will see a message that says "The authenticity of host `x.x.x.x` can't be established ... Are you sure you want to continue connecting". This is normal for the first connection. Type `yes` and press `Enter`.</Note>
 


### PR DESCRIPTION
- point to get-started instead of outside resource for generating a keypair
- add codeblock examples for ssh command
- remove material now duplicated in get-started