### PR TITLE
docs: fix sdks section slug

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -23,6 +23,7 @@ navigation:
       - page: SSH Keys
         path: ./docs/pages/ssh/ssh-keys.mdx
   - section: SDKs
+    slug: sdks
     contents:
       - page: Python SDK
         path: ./docs/pages/sdks/python-sdk.mdx


### PR DESCRIPTION
Added slug for path to create correctly when using mixed case in a section name, as otherwise fern will auto-generate a path like SDKs as sd-ks.