### PR TITLE
docs: updates to ssh docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -20,8 +20,9 @@ navigation:
     contents:
       - page: What is SSH?
         path: ./docs/pages/ssh/what-is-ssh.mdx
-      - page: SSH Keys
-        path: ./docs/pages/ssh/ssh-keys.mdx
+      - page: How to use SSH Keys
+        path: ./docs/pages/ssh/use-ssh-keys.mdx
+        slug: use-ssh-keys
   - section: SDKs
     slug: sdks
     contents:
@@ -31,6 +32,7 @@ navigation:
     contents:
       - page: Instance Configurations
         path: ./docs/pages/configurations-and-operating-systems/configurations.mdx
+        slug: configurations
       - page: Operating Systems
         path: ./docs/pages/configurations-and-operating-systems/operating-systems.mdx
   - api: API Reference

--- a/fern/docs/pages/authentication.mdx
+++ b/fern/docs/pages/authentication.mdx
@@ -21,7 +21,7 @@ Example:
 
 ## SSH keys
 
-An **SSH key** is required to create and log into an instance. [Learn how to create and manage SSH keys.](/ssh/ssh-keys)
+An **SSH key** is required to create and log into an instance. [Learn how to create and manage SSH keys.](/ssh/use-ssh-keys)
 
 ### Use your SSH key
 

--- a/fern/docs/pages/dashboard.mdx
+++ b/fern/docs/pages/dashboard.mdx
@@ -21,7 +21,7 @@ Having trouble accessing the Dashboard? Contact [support](mailto:support@fluidst
 
 From the left sidebar of the Dashboard, select [GPU Instances](https://dashboard.fluidstack.io/dashboard/instances) to display all instances on your account. For each instance, the name, configuration, IP address, username for SSH login, associated SSH keys, SSH port, and instance status is displayed.
 
-<Tip>You can also manage instances through our API. See the [Instances API reference](/api-reference/instances).</Tip>
+<Note>You can also manage instances through our API. See the [Instances API reference](/api-reference/instances).</Note>
 
 ### Add a GPU instance
 
@@ -39,26 +39,24 @@ Starting and stopping existing instances is performed through our API. View the 
 
 SSH keys are used to authenticate for command-line access to instances.
 
-<Tip>You can also manage SSH keys through our API. See the [SSH Keys](/ssh/ssh-keys) page and the [SSH Keys API reference](/api-reference/ssh-keys/).</Tip>
+<Note>You can also manage SSH keys through our API. See the [How to use SSH Keys](/ssh/use-ssh-keys) page and the [SSH Keys API reference](/api-reference/ssh-keys/).</Note>
 
 ### View SSH keys
 
-From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).
+<Markdown src="../snippets/view-ssh-keys-dashboard.mdx" />
 
 ### Add (create) an SSH key
 
-1. From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).
-2. Click the **Add SSH key** button in the upper-right corner. A dialog will appear.
-3. In the dialog's **Name** field, input a unique name for this SSH key. 
-4. Paste your public key in the field labeled **Public SSH key**.
-5. Click **Confirm**.
+<Markdown src="../snippets/add-ssh-key-dashboard.mdx" />
+
+<Tip>
+  Don't have a public key? See: [Generate a public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair).
+</Tip>
 
 ### Delete an SSH key
 
 <Markdown src="../snippets/delete-ssh-key-warning.mdx" />
-
-1. From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).
-2. Click the red `delete` button next to the SSH key you want to delete.
+<Markdown src="../snippets/delete-ssh-key-dashboard.mdx" />
 
 ## Manage API keys
 
@@ -82,7 +80,7 @@ From the left sidebar of the Dashboard, select [API Keys](https://dashboard.flui
 
 From the left sidebar of the Dashboard, select [Billing](https://dashboard.fluidstack.io/dashboard/billing).
 
-From the **Overview** tab, you can view your credit balance and deposit funds. 
+From the **Overview** tab, view your credit balance and deposit funds. 
 
 From the **Billing history** tab, access your detailed billing history, including the date, type, amount, and instance ID for every instance charge. Deposited funds are also shown in this tab.
 

--- a/fern/docs/pages/get-started.mdx
+++ b/fern/docs/pages/get-started.mdx
@@ -12,8 +12,9 @@ This tutorial leads you through the following steps:
 
 ## Prerequisites
 
- - An SSH key added to your FluidStack account. See: [Create an SSH key](/ssh/use-ssh-keys#create-an-ssh-key).
  - <Markdown src="../snippets/api-key.mdx" />
+ - An SSH key must exist on your FluidStack account. See: [Create an SSH key](/ssh/use-ssh-keys#create-an-ssh-key).
+
 
 ## Steps
 

--- a/fern/docs/pages/get-started.mdx
+++ b/fern/docs/pages/get-started.mdx
@@ -12,7 +12,7 @@ This tutorial leads you through the following steps:
 
 ## Prerequisites
 
- - An SSH key added to your FluidStack account. See: [Create an SSH key](/ssh/ssh-keys#create-an-ssh-key).
+ - An SSH key added to your FluidStack account. See: [Create an SSH key](/ssh/use-ssh-keys#create-an-ssh-key).
  - <Markdown src="../snippets/api-key.mdx" />
 
 ## Steps
@@ -38,20 +38,20 @@ When creating a GPU instance, you must specify one or more SSH keys. You can use
     The following values are required to create an instance:
 
     - the `name` of the instance
-    - the`gpu_type` (See the `gpu_model` field from [Configurations](/configurations-and-operating-systems/configurations).)
+    - the`gpu_type` (See the `gpu_model` field from [Instance Configurations](/configurations-and-operating-systems/configurations).)
     - the `ssh_key_name`
     
     These values are optional:
     - `gpu_count` (Default: `1`)
-    - `operating_system_label` (See the `label` field from [Operating Systems](/api-reference/templates/list). Default: `"ubuntu_20_04_lts"`)
+    - `operating_system_label` (See the `label` field from [Operating Systems](/configurations-and-operating-systems/operating-systems). Default: `"ubuntu_20_04_lts"`)
 
-    If you prefer, you can use a different [configuration](/configurations-and-operating-systems/configurations) and/or [operating system](/configurations-and-operating-systems/operating-systems). 
+    If you prefer, you can use a different [instance configuration](/configurations-and-operating-systems/configurations) and/or [operating system](/configurations-and-operating-systems/operating-systems). 
 
     To create an instance, call the API using the cURL command below. Replace `<api_key>` with your API key, and `<ssh_key_name>` with your SSH key's name:
 
     <EndpointRequestSnippet endpoint="POST /instances" />
 
-    If you have multiple SSH keys you'd like to associate with this instance, use a comma-separated list:
+    If you have multiple SSH keys you'd like to associate with this instance, provide a comma-separated list in the cURL command:
 
     ```bash Multiple SSH keys example {2-4}
         "ssh_keys": [
@@ -61,17 +61,17 @@ When creating a GPU instance, you must specify one or more SSH keys. You can use
         ]
     ```
 
-    If your request is sent successfully, the endpoint responds with the created instance's details, including its `id`, `name`, `gpu_type`, and `operating_system_label`:
+    If your request succeeds, the endpoint responds with the created instance's details, including its `id`, `name`, `gpu_type`, and `operating_system_label`:
 
     <EndpointResponseSnippet endpoint="POST /instances" />
 
     Take note of the `id` of your instance. 
 
-    Check the instance's status using the [`GET /instances`](/api-reference/instances/list) endpoint:
+    Request the instance's status using the [`GET /instances`](/api-reference/instances/list) endpoint:
 
     <EndpointRequestSnippet endpoint="GET /instances" />
 
-    Initially, the instance's `status` will be `pending`. Once the instance is created and available, its `status` updates to `running` and an IP address is assigned.
+    Initially, the instance's `status` will be `pending`. Once the instance is created and available, its `status` updates to `running` and it is assigned an IP address.
 
     Example:
     <EndpointResponseSnippet endpoint="GET /instances" />
@@ -95,6 +95,7 @@ To close your connection and log out from the instance, type `exit` into your SS
 
 <AccordionGroup>
   <Accordion title="Use the FluidStack Dashboard">
+    <Markdown src="../snippets/open-dashboard.mdx" />
     <Markdown src="../snippets/delete-instance-dashboard.mdx" />
   </Accordion>
 
@@ -109,13 +110,14 @@ To close your connection and log out from the instance, type `exit` into your SS
   curl -X DELETE https://platform.fluidstack.io/instances/i-d02e976e-29e4-4857-8787-2ebe17fa4972 \
   -H "api-key: api_key_j8FaG34rGUFDig1111qerdP1f5MfEeW9AI"
 ```
-    To confirm that your instance was deleted, you can call the [`GET /instances`](/api-reference/instances/list) endpoint again as you did at the end of Step 1.
-
+    To confirm that your instance was deleted, call the [`GET /instances`](/api-reference/instances/list) endpoint again as you did at the end of Step 1.
 
   </Accordion>
 </AccordionGroup>
 
 </Steps>
+
+Congratulations! You have successfully created an instance, accessed it using SSH, and (optionally) deleted the instance. 
 
 ## What's next
 

--- a/fern/docs/pages/programmatic-instance-management.mdx
+++ b/fern/docs/pages/programmatic-instance-management.mdx
@@ -2,7 +2,7 @@ The Python script on this page provides an example of how the [FluidStack API](/
 
 ## Prerequisites
   - <Markdown src="../snippets/api-key.mdx" />
-  - A [public/private key pair](/ssh/ssh-keys#generate-a-publicprivate-key-pair)
+  - A [public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair)
   - Basic familiarity with [Python](https://python.org) and Python 3+ installed
   - The [`requests`](https://pypi.org/project/requests/) module installed in your Python environment
 
@@ -44,7 +44,7 @@ The Python script on this page provides an example of how the [FluidStack API](/
 
 ## Example script 
 
-```python maxLines=30 title="Python" {15,33,55,77,80}
+```python maxLines=30 title="Python" {14,35,57,79,82}
 import requests
 from pathlib import Path
 import os
@@ -54,7 +54,6 @@ import json
 api_url = "https://platform.fluidstack.io/"
 api_key = "<your_api_key>"
 
-# Provide the API key in a header
 headers = {
     "api-key": api_key
 }

--- a/fern/docs/pages/sdks/python-sdk.mdx
+++ b/fern/docs/pages/sdks/python-sdk.mdx
@@ -45,7 +45,7 @@ client.ssh_keys.create(
 
 ## Async client
 
-The SDK exports an async client so that you can make non-blocking calls to our API.
+The SDK exports an async client for making non-blocking calls to our API.
 
 ```python 
 from fluidstack.client import AsyncFluidStack
@@ -66,7 +66,7 @@ asyncio.run(main())
 
 ### Timeouts
 
-By default, requests time out after 60 seconds. You can configure this with the `timeout_in_seconds` option at the client or request level.
+By default, requests will time out after 60 seconds. Configure the timeout duration with the `timeout_in_seconds` option at the client or request level.
 
 ```python
 from fluidstack.client import FluidStack

--- a/fern/docs/pages/ssh/use-ssh-keys.mdx
+++ b/fern/docs/pages/ssh/use-ssh-keys.mdx
@@ -83,7 +83,7 @@ cat ~/.ssh/id_ecdsa_256.pub
 
 ## Create an SSH key
 
-Use your public key to create an SSH key on your FluidStack account. 
+Use your public key to create an SSH key on your FluidStack account. If you don't have a public key, see: [Generate a public/private key pair](#generate-a-publicprivate-key-pair).
 
 <Tip>In this context, "creating an SSH key" means "storing (adding) a copy of your public key on your FluidStack account." The stored SSH key is identical to your public key.</Tip>
 

--- a/fern/docs/pages/ssh/use-ssh-keys.mdx
+++ b/fern/docs/pages/ssh/use-ssh-keys.mdx
@@ -1,22 +1,18 @@
-An **SSH key** is required to create a cloud-based GPU instance with FluidStack. Once the instance is running, use the SSH key for remote command-line access to the instance.
+---
+subtitle: Connect to an instance using an SSH key
+---
 
-## What is an SSH key?
-
-FluidStack allows [Secure Shell (SSH)](/ssh/what-is-ssh) access to instances. For improved security, we use [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) for authentication instead of a password. This method requires that you provide your own **public/private key pair**. 
-
-Your public key is stored on your instance as your SSH key. Its corresponding private key is stored locally on the computer that you use to access your instance. SSH access is granted by verifying that your private key corresponds to the public key. As an analogy, you can think of a public key as a lock that only your private key can unlock.
-
-<Tip>Public/private key pairs are used for many purposes, not only SSH. For example, they are used in file encryption, digital signatures, and cryptocurrency transactions.</Tip>
+You must provide at least one [SSH key](/ssh/what-is-ssh#ssh-keys) when you create a cloud-based GPU instance with FluidStack. Once the instance is running, use one of the provided keys for remote command-line access to the instance.
 
 ## Generate a public/private key pair
 
 <Markdown src="../../snippets/public-key-formats.mdx" />
 
-If you already have a public/private key pair of a supported format, you can use it instead of generating a new pair.
+If you already have a public/private key pair of a supported format, you can use that pair instead of generating a new one.
 
-You can generate a public/private key pair for authenticating SSH connections by using a command-line tool called **ssh-keygen**. This tool comes pre-installed on nearly all operating systems.
+Follow the steps below to generate a key pair with a command-line tool called **ssh-keygen**. This tool is pre-installed on nearly all operating systems.
 
-You can use any supported format for your key pair. The tabs below contain instructions for generating a key pair with either the [RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem)) algorithm or [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm) algorithm.
+Use any supported format for your key pair. The tabs below contain instructions for generating a key pair with either the [RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem)) algorithm or [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm) algorithm.
 
 <Frame>
 <Tabs>
@@ -76,8 +72,6 @@ ls ~/.ssh
 cat ~/.ssh/id_ecdsa_256.pub
 ```
     </Steps>
-    
-
   </Tab>
 
 </Tabs>
@@ -89,16 +83,19 @@ cat ~/.ssh/id_ecdsa_256.pub
 
 ## Create an SSH key
 
-Use your public key to create an SSH key on your FluidStack account. In this context, _creating an SSH key_ means _storing (adding) a copy of your public key on your FluidStack account_. The stored SSH key is identical to your public key.
+Use your public key to create an SSH key on your FluidStack account. 
+
+<Tip>In this context, "creating an SSH key" means "storing (adding) a copy of your public key on your FluidStack account." The stored SSH key is identical to your public key.</Tip>
 
 <AccordionGroup>
 
   <Accordion title="Use the FluidStack Dashboard">
-    See [Dashboard - Create an SSH key](/dashboard#create-an-ssh-key).
+    <Markdown src="../../snippets/open-dashboard.mdx" />
+    <Markdown src="../../snippets/add-ssh-key-dashboard.mdx" />
   </Accordion>
 
   <Accordion title="Use the FluidStack API">
-    Create an SSH key by using the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint. You can call this endpoint programmatically, or by using a command-line tool such as [cURL](https://curl.se/):
+    Create an SSH key by using the [`POST /ssh_keys`](/api-reference/ssh-keys/create) endpoint.
 
     <EndpointRequestSnippet endpoint="POST /ssh_keys" />
 
@@ -120,11 +117,12 @@ Use your public key to create an SSH key on your FluidStack account. In this con
 
 <AccordionGroup>
   <Accordion title="Use the FluidStack Dashboard">
-    See [Dashboard - View SSH keys](/dashboard#view-ssh-keys).
+    <Markdown src="../../snippets/open-dashboard.mdx" />
+
+    <Markdown src="../../snippets/view-ssh-keys-dashboard.mdx" />
   </Accordion>
 
   <Accordion title="Use the FluidStack API">
-
     View SSH keys on your FluidStack account by using the [`GET /ssh_keys`](/api-reference/ssh-keys/list) endpoint:
 
     <EndpointRequestSnippet endpoint="GET /ssh_keys" />
@@ -151,7 +149,8 @@ Use your public key to create an SSH key on your FluidStack account. In this con
 <Markdown src="../../snippets/delete-ssh-key-warning.mdx" />
 <AccordionGroup>
   <Accordion title="Use the FluidStack Dashboard">
-    See [Dashboard - Delete an SSH key](/dashboard#delete-an-ssh-key).
+    <Markdown src="../../snippets/open-dashboard.mdx" />
+    <Markdown src="../../snippets/delete-ssh-key-dashboard.mdx" />
   </Accordion>
 
   <Accordion title="Use the FluidStack API">
@@ -166,3 +165,9 @@ Use your public key to create an SSH key on your FluidStack account. In this con
 ```
   </Accordion>
 </AccordionGroup>
+
+## Connect to an instance with an SSH key
+
+Use your private key to authenticate when connecting to a running instance via SSH. The instance has a list of SSH keys associated with it, provided at the time that the instance was created. The private key must correspond to one of those SSH keys.
+
+<Markdown src="../../snippets/connect-with-ssh.mdx" />

--- a/fern/docs/pages/ssh/what-is-ssh.mdx
+++ b/fern/docs/pages/ssh/what-is-ssh.mdx
@@ -1,22 +1,26 @@
 ## The Secure Shell (SSH) protocol
 SSH is a cryptographic network protocol used for secure access to a networked computer. The data transmitted between the client and server is protected with strong encryption algorithms, ensuring privacy and data integrity.
 
-FluidStack instances have SSH servers enabled, with authentication through [SSH keys](/ssh/ssh-keys).
+FluidStack instances have SSH servers enabled. These servers authenticate using [SSH keys](/ssh/use-ssh-keys).
+
+## SSH keys
+
+FluidStack allows [Secure Shell (SSH)](/ssh/what-is-ssh) access to instances. For improved security, we use [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) for authentication instead of a password. This method requires that you provide your own **public/private key pair**. 
+
+Your public key is stored on your instance as your SSH key. Its corresponding private key is stored locally on the computer that you use to access your instance. SSH access is granted by verifying that your private key corresponds to the public key. As an analogy, think of a public key as a lock that only your private key can unlock.
+
+<Tip>Public/private key pairs are used for many purposes, not only SSH. For example, they are used in file encryption, digital signatures, and cryptocurrency transactions.</Tip>
 
 ## SSH clients
 
-You can use an SSH client to remotely connect to an instance. Nearly all computers have an SSH client installed by default. To verify if you have one installed, enter the following command in your CLI shell:
+An SSH client is used to remotely connect to an instance. Nearly all computers have an SSH client installed by default. To test if you have one installed, enter the following command in your CLI shell:
 
 ```shell
 ssh -v
 ```
 
-Expected output: a list of usage options. 
+You should see a list of usage options. If you see an output indicating that the command was not found, install an SSH client. Two popular options are [OpenSSH](https://wiki.openssl.org/index.php/Binaries) and [Putty](https://www.putty.org/).
 
-If you see an output indicating that the command was not found, you will need to install an SSH client. Two popular options are [OpenSSH](https://wiki.openssl.org/index.php/Binaries) and [Putty](https://www.putty.org/).
+## What's next?
 
-### Connecting to an instance
-
-Use your private key to authenticate when connecting to a running instance via SSH. The private key must correspond to a public key that you used for one of the SSH keys associated with that instance.
-
-<Markdown src="../../snippets/connect-with-ssh.mdx" />
+- In our guide [How to use SSH keys](/ssh/use-ssh-keys), learn how to generate an public/private key pair and use it to connect to an instance.

--- a/fern/docs/snippets/add-ssh-key-dashboard.mdx
+++ b/fern/docs/snippets/add-ssh-key-dashboard.mdx
@@ -1,0 +1,5 @@
+1. From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).
+2. Click the **Add SSH key** button in the upper-right corner. A dialog will appear.
+3. In the dialog's **Name** field, input a unique name for this SSH key. 
+4. Paste your public key in the field labeled **Public SSH key**.
+5. Click **Confirm**.

--- a/fern/docs/snippets/delete-ssh-key-dashboard.mdx
+++ b/fern/docs/snippets/delete-ssh-key-dashboard.mdx
@@ -1,0 +1,2 @@
+1. From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).
+2. Click the red `delete` button next to the SSH key you want to delete.

--- a/fern/docs/snippets/open-dashboard.mdx
+++ b/fern/docs/snippets/open-dashboard.mdx
@@ -1,0 +1,1 @@
+Open the [FluidStack Dashboard](https://dashboard.fluidstack.io).

--- a/fern/docs/snippets/view-ssh-keys-dashboard.mdx
+++ b/fern/docs/snippets/view-ssh-keys-dashboard.mdx
@@ -1,0 +1,1 @@
+From the left sidebar of the Dashboard, select [SSH Keys](https://dashboard.fluidstack.io/dashboard/ssh-keys).


### PR DESCRIPTION
- rename 'SSH keys' page to 'How to use SSH keys'; make page slug 'use-ssh-keys'; update links
- add SSH key dashboard snippets for reuse
- move explanatory info from 'How to use SSH keys' page to 'What is SSH?' page
- add what's next section to 'What is SSH?'
