### PR TITLE
docs: add servers array back to openapi

### DIFF
--- a/fern/openapi/fluidstack-openapi.json
+++ b/fern/openapi/fluidstack-openapi.json
@@ -4,6 +4,12 @@
     "title": "Fluidstack API Service",
     "version": "0.1.0"
   },
+  "servers": [
+    {
+      "url": "https://platform.fluidstack.io",
+      "description": "Production server"
+    }
+  ],
   "paths": {
     "/healthcheck": {
       "get": {


### PR DESCRIPTION
Missed adding the servers array back to the openapi when reviewing https://github.com/fluidstackio/fern-config/pull/41 - doing it manually for now, but I've submitted a PR (https://github.com/fluidstackio/phoenix/pull/128) that will make sure that future FastAPI-generated openapi files will have the servers array automatically.