### PR TITLE
docs: moved openapi examples to overrides file

### DIFF
--- a/fern/openapi/fluidstack-openapi.json
+++ b/fern/openapi/fluidstack-openapi.json
@@ -63,8 +63,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Api-Key",
-              "example": "your-api-key"
+              "title": "Api-Key"
             }
           },
           {
@@ -521,8 +520,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Ssh Key Name",
-              "example": "my_key"
+              "title": "Ssh Key Name"
             }
           },
           {
@@ -607,34 +605,7 @@
                     "$ref": "#/components/schemas/ConfigurationResponse"
                   },
                   "title": "Response List Available Configurations List Available Configurations Get"
-                },
-                "example": [
-                  {
-                    "id": "c-bd6a5e05-a3fd-4642-a82b-9da5fa784401",
-                    "gpu_model": {
-                      "name": "RTX_A6000_48GB", "memory_size_mb": 48
-                    },
-                    "cpu_model": "generic",
-                    "gpu_count": 1,
-                    "cpu_count": 16,
-                    "nvme_storage_size_gb": 425,
-                    "memory_size_mb": 59.0,
-                    "estimated_provisioning_time_minutes": 0
-                  },
-                  {
-                    "id":"c-31078703-a4b2-4bfb-803c-abf887378e31",
-                    "gpu_model": {
-                      "name": "RTX_A6000_48GB",
-                      "memory_size_mb": 48
-                    },
-                    "cpu_model": "generic",
-                    "gpu_count": 1,
-                    "cpu_count": 16,
-                    "nvme_storage_size_gb": 425,
-                    "memory_size_mb": 59.0,
-                    "estimated_provisioning_time_minutes": 0
-                  }
-                ]
+                }
               }
             }
           },
@@ -697,19 +668,7 @@
                     "$ref": "#/components/schemas/OperatingSystemResponse"
                   },
                   "title": "Response List Available Os Templates List Available Os Templates Get"
-                },
-                "example": [
-                  {
-                    "name": "Ubuntu 22.04 LTS",
-                    "description": "Ubuntu 22.04 LTS plain",
-                    "label": "ubuntu_22_04_lts"
-                  },
-                  {
-                    "name": "Ubuntu 20.04 LTS",
-                    "description": "Ubuntu 20.04 LTS plain",
-                    "label": "ubuntu_20_04_lts"
-                  }
-                ]
+                }
               }
             }
           },
@@ -944,8 +903,7 @@
       },
       "EntityId": {
         "type": "string",
-        "title": "EntityId",
-        "example": "c-36ba4b56-fd30-4fc1-bb90-7c9493bab123"
+        "title": "EntityId"
       },
       "GPUModelResponse": {
         "properties": {
@@ -1061,7 +1019,7 @@
               }
             ],
             "title": "Username",
-            "description": "The username used to connect to the instance\n\nFor example, to connect to the instance via SSH, use; \"ssh <username>@<ip_address> -p <ssh_port>\".",
+            "description": "The username used to connect to the instance\n\nFor example, to connect to the instance via SSH, use `ssh <username>@<ip_address> -p <ssh_port>`.",
             "default": "ubuntu"
           },
           "ssh_port": {
@@ -1255,7 +1213,6 @@
           "ubuntu_22_04_lts_nvidia"
         ],
         "title": "SupportedOperatingSystem",
-        "example": "ubuntu_20_04_lts",
         "default": "ubuntu_20_04_lts"
       },
       "ValidationError": {

--- a/fern/openapi/openapi-overrides.yml
+++ b/fern/openapi/openapi-overrides.yml
@@ -49,7 +49,12 @@ paths:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: create
       x-fern-examples:
-        - response:
+        - request:
+            name: my_instance_name
+            gpu_type: RTX_A5000_24GB
+            ssh_keys: ['my_ssh_key']
+            operating_system_label: ubuntu_20_04_lts_nvidia
+          response:
             body:
               id: i-1234567890
               name: my_instance_name
@@ -67,7 +72,9 @@ paths:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: stop
       x-fern-examples:
-        - response:
+        - path-parameters:
+            instance_id: '{instance_id}'
+          response:
             body:
               id: i-1234567890
               status: stopped
@@ -95,7 +102,9 @@ paths:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: start
       x-fern-examples:
-        - response:
+        - path-parameters:
+            instance_id: '{instance_id}'
+          response:
             body:
               id: i-1234567890
               status: running
@@ -118,7 +127,6 @@ paths:
                 memory_size_gb: 30
                 estimated_provisioning_time_minutes: 5
               created_at: '2024-06-19T21:01:42.660889'
-
   /ssh_keys:
     get:
       x-fern-sdk-group-name: ssh_keys
@@ -127,15 +135,18 @@ paths:
         - response:
             body:
               - name: my_ssh_key
-                public_key: <public_key>
+                public_key: <my_public_key>
     post:
       x-fern-sdk-group-name: ssh_keys
       x-fern-sdk-method-name: create
       x-fern-examples:
-        - response:
+        - request:
+            name: my_ssh_key
+            public_key: <my_public_key>
+          response:
             body:
               name: my_ssh_key
-              public_key: <public_key>
+              public_key: <my_public_key>
   /ssh_keys/{ssh_key_name}:
     delete:
       x-fern-sdk-group-name: ssh_keys

--- a/fern/openapi/openapi-overrides.yml
+++ b/fern/openapi/openapi-overrides.yml
@@ -21,32 +21,128 @@ paths:
     get:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: list
+      x-fern-examples:
+        - response:
+            body:
+              - id: i-1234567890
+                status: running
+                username: ubuntu
+                ssh_port: '22'
+                ssh_keys:
+                  - my_ssh_key
+                ip_address: 192.0.2.0
+                name: my_instance_name
+                current_rate: 1
+                configuration:
+                  id: c-1234567890
+                  gpu_model:
+                    name: RTX_A5000_24GB
+                    memory_size_gb: 24
+                  cpu_model: generic
+                  gpu_count: 1
+                  cpu_count: 8
+                  nvme_storage_size_gb: 200
+                  memory_size_gb: 30.0
+                  estimated_provisioning_time_minutes: 5
+                created_at: '2024-01-15T09:30:00Z'
     post:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: create
+      x-fern-examples:
+        - response:
+            body:
+              id: i-1234567890
+              name: my_instance_name
+              gpu_type: RTX_A5000_24GB
+              operating_system_label: ubuntu_20_04_lts_nvidia
   /instances/{instance_id}:
     delete:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: delete
+      x-fern-examples:
+        - path-parameters:
+            instance_id: '{instance_id}'
   /instances/{instance_id}/stop:
     put:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: stop
+      x-fern-examples:
+        - response:
+            body:
+              id: i-1234567890
+              status: stopped
+              username: ubuntu
+              ssh_port: '22'
+              ssh_keys:
+                - my_key
+              ip_address: 192.0.2.0
+              name: my_instance_name
+              current_rate: null
+              configuration:
+                id: c-1234567890
+                gpu_model:
+                  name: RTX_A5000_24GB
+                  memory_size_gb: 24
+                cpu_model: generic
+                gpu_count: 1
+                cpu_count: 8
+                nvme_storage_size_gb: 200
+                memory_size_gb: 30
+                estimated_provisioning_time_minutes: 5
+              created_at: '2024-06-19T21:01:42.660889'
   /instances/{instance_id}/start:
     put:
       x-fern-sdk-group-name: instances
       x-fern-sdk-method-name: start
+      x-fern-examples:
+        - response:
+            body:
+              id: i-1234567890
+              status: running
+              username: ubuntu
+              ssh_port: '22'
+              ssh_keys:
+                - my_ssh_key
+              ip_address: 192.0.2.0
+              name: my_instance_name
+              current_rate: null
+              configuration:
+                id: c-1234567890
+                gpu_model:
+                  name: RTX_A5000_24GB
+                  memory_size_gb: 24
+                cpu_model: generic
+                gpu_count: 1
+                cpu_count: 8
+                nvme_storage_size_gb: 200
+                memory_size_gb: 30
+                estimated_provisioning_time_minutes: 5
+              created_at: '2024-06-19T21:01:42.660889'
+
   /ssh_keys:
     get:
       x-fern-sdk-group-name: ssh_keys
       x-fern-sdk-method-name: list
+      x-fern-examples:
+        - response:
+            body:
+              - name: my_ssh_key
+                public_key: <public_key>
     post:
       x-fern-sdk-group-name: ssh_keys
       x-fern-sdk-method-name: create
+      x-fern-examples:
+        - response:
+            body:
+              name: my_ssh_key
+              public_key: <public_key>
   /ssh_keys/{ssh_key_name}:
     delete:
       x-fern-sdk-group-name: ssh_keys
       x-fern-sdk-method-name: delete
+      x-fern-examples:
+        - path-parameters:
+            ssh_key_name: '{ssh_key_name}'
   /api_keys:
     get:
       x-fern-ignore: true
@@ -59,6 +155,23 @@ paths:
     get:
       x-fern-sdk-group-name: configurations
       x-fern-sdk-method-name: list
+      x-fern-examples:
+        - response:
+            body:
+              - gpu_type: RTX_A5000_24GB
+                gpu_counts:
+                  - 1
+                  - 2
+                  - 4
+                  - 8
+                price_per_gpu_hr: '5'
+                estimated_provisioning_time_minutes: 5
+              - gpu_type: H100_PCIE_80GB
+                gpu_counts:
+                  - 1
+                  - 8
+                price_per_gpu_hr: '5'
+                estimated_provisioning_time_minutes: 5
   /list_user_ssh_keys:
     get:
       x-fern-ignore: true
@@ -71,6 +184,12 @@ paths:
     get:
       x-fern-sdk-group-name: templates
       x-fern-sdk-method-name: list
+      x-fern-examples:
+        - response:
+            body:
+              - name: Ubuntu 20.04 LTS (Nvidia)
+                description: Ubuntu 20.04 LTS with Nvidia/CUDA 12 drivers preinstalled
+                label: ubuntu_20_04_lts_nvidia
   /payments/create-intent:
     post:
       x-fern-ignore: true


### PR DESCRIPTION
This PR ensures that the examples used in the SDK and API reference (such as when showing sample requests, responses, and path parameters in cURL and SDK examples) are generated using `openapi-overrides.yml`. This means they will persist even when the openapi file is regenerated and replaced. 