### PR TITLE
docs: update openapi.json

### DIFF
--- a/fern/openapi/fluidstack-openapi.json
+++ b/fern/openapi/fluidstack-openapi.json
@@ -668,7 +668,7 @@
           }
         },
         "type": "object",
-        "required": ["name", "gpu_type", "ssh_key"],
+        "required": ["gpu_type", "ssh_key"],
         "title": "CreateInstanceRequest"
       },
       "CreateInstanceResponse": {


### PR DESCRIPTION
- revert the change to having the name as required, per confirmed it is not technically required for instance creation