### PR TITLE
docs: update python SDK guide, add typescript SDK guide

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -82,6 +82,7 @@ navigation:
             path: ./docs/pages/sdks/python/use-python-sdk.mdx
             slug: use-python-sdk
       - section: TypeScript
+        slug: typescript
         contents:
           - page: Overview
             path: ./docs/pages/sdks/typescript/overview.mdx

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -81,6 +81,13 @@ navigation:
           - page: How to use the Python SDK
             path: ./docs/pages/sdks/python/use-python-sdk.mdx
             slug: use-python-sdk
+      - section: TypeScript
+        contents:
+          - page: Overview
+            path: ./docs/pages/sdks/typescript/overview.mdx
+          - page: How to use the TypeScript SDK
+            path: ./docs/pages/sdks/typescript/use-typescript-sdk.mdx
+            slug: use-typescript-sdk
   - api: API reference
     snippets:
       python: fluidstack

--- a/fern/docs/pages/dashboard/instances.mdx
+++ b/fern/docs/pages/dashboard/instances.mdx
@@ -20,7 +20,7 @@ You should then see the newly created instance in the GPU Instances page. Initia
 
 ## Delete an instance
 
-<Markdown src="../../snippets/delete-instance-dashboard.mdx" />
+<Markdown src='../../snippets/delete-instance-dashboard.mdx' />
 
 ## Stop and start an instance
 

--- a/fern/docs/pages/dashboard/ssh-keys.mdx
+++ b/fern/docs/pages/dashboard/ssh-keys.mdx
@@ -4,13 +4,13 @@ slug: dashboard/ssh-keys
 
 SSH keys are used to authenticate for remote, command-line access to instances.
 
-<Note>You can also manage SSH keys through our API. See the [How to use SSH Keys](/ssh/use-ssh-keys) page and the [SSH Keys API reference](/api-reference/ssh-keys/).</Note>
+<Note title="Note">You can also manage SSH keys through our API. See the [How to use SSH Keys](/ssh/use-ssh-keys) page and the [SSH Keys API reference](/api-reference/ssh-keys/).</Note>
 
 ### Add an SSH key
 
 <Markdown src='../../snippets/add-ssh-key-dashboard.mdx' />
 
-<Tip>
+<Tip title="Tip">
   Don't have a public key? See: [Generate a public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair).
 </Tip>
 

--- a/fern/docs/pages/dashboard/ssh-keys.mdx
+++ b/fern/docs/pages/dashboard/ssh-keys.mdx
@@ -8,7 +8,7 @@ SSH keys are used to authenticate for remote, command-line access to instances.
 
 ### Add an SSH key
 
-<Markdown src="../../snippets/add-ssh-key-dashboard.mdx" />
+<Markdown src='../../snippets/add-ssh-key-dashboard.mdx' />
 
 <Tip>
   Don't have a public key? See: [Generate a public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair).
@@ -16,5 +16,5 @@ SSH keys are used to authenticate for remote, command-line access to instances.
 
 ### Delete an SSH key
 
-<Markdown src="../../snippets/delete-ssh-key-warning.mdx" />
-<Markdown src="../../snippets/delete-ssh-key-dashboard.mdx" />
+<Markdown src='../../snippets/delete-ssh-key-warning.mdx' />
+<Markdown src='../../snippets/delete-ssh-key-dashboard.mdx' />

--- a/fern/docs/pages/get-started/api-overview.mdx
+++ b/fern/docs/pages/get-started/api-overview.mdx
@@ -25,41 +25,53 @@ An **API key** is required for authentication to use the FluidStack API. Your AP
 Whenever you make a call to the FluidStack API, include your API key in the request headers with a header name of `api-key`. Otherwise, your call will fail. 
 
 Example:
-<EndpointRequestSnippet endpoint="GET /instances" />
+<EndpointRequestSnippet endpoint='GET /instances' />
 
 ### Requests and responses
 
-All request and response bodies are sent in JSON format. When sending data in the body of a request, always include the header `"Content-Type: application/json"`.
+All request and response bodies are sent in JSON format. When sending data in the body of a request, always include the header `'Content-Type: application/json'`.
 
 ## Programmatic API use
 
 ### Instance management
 
-See an example of [how to use Python to manage instances](/instances/manage/programmatic).
+See our tutorial about [how to use Python or TypeScript to manage instances](/instances/manage/programmatic).
 
-### Python SDK
+### SDKs
 
-Use our [Python SDK](/sdks/python/overview) to interface with our API in your Python applications.
+Use our [Python SDK](/sdks/python/overview) or [TypeScript SDK](/sdks/typescript/overview) to interface with our API in your applications.
 
 ### Secure use of your API key
 
 For security, avoid placing your API key in any file that could potentially be seen by others.
 
-There are many ways to safeguard the privacy of your API key. One common approach is using an `.env` file. Create a file named `.env` or look for one that already exists in your project. Add your key to it, then use the `dotenv` module to import it into your Python file. 
+There are several ways to safeguard the privacy of your API key. One common approach is using an `.env` file. Create a file named `.env` or look for one that already exists in your project. Add your key to it, then use the `dotenv` module to import it into your Python or TypeScript file. 
+
+<Note title="Note">
+The `dotenv` module is not available by default and must be installed before use. It is called `dotenv` in both Python and Node.js/TypeScript.
+</Note>
 
 Example:
 
 ```properties .env file
-FLUIDSTACK_API_KEY="api_key_j123YourAPIKey"
+FLUIDSTACK_API_KEY='api_key_j123YourAPIKey'
 ```
+
 <CodeBlocks>
+
 ```python Python
 from dotenv import load_dotenv
 import os
 
-load_dotenv() # load the variables from your .env file
+load_dotenv() # Load environment variables from .env file
 
-api_key = os.getenv('FLUIDSTACK_API_KEY') # Use your API key securely
+# Get the API key from the environment variable
+api_key = os.getenv('FLUIDSTACK_API_KEY')
+
+if api_key is None:
+    raise ValueError("The FLUIDSTACK_API_KEY environment variable is not set in the .env file.")
+
+...
 ```
 
 ```python Python SDK
@@ -67,13 +79,57 @@ from FluidStack.client import FluidStack
 from dotenv import load_dotenv
 import os
 
-load_dotenv() # load the variables from your .env file
+# Load environment variables from .env file
+load_dotenv()
 
+# Get the API key from the environment variable
+api_key = os.getenv('FLUIDSTACK_API_KEY')
+
+if api_key is None:
+    raise ValueError("The FLUIDSTACK_API_KEY environment variable is not set in the .env file.")
+
+# 1: Instantiate a client
 client = FluidStack(
-  api_key = os.getenv('FLUIDSTACK_API_KEY') # Use your API key securely
+    api_key=api_key
 )
+
+...
+```
+
+```ts TypeScript
+import dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config();
+
+// Get the API key from the environment variable
+const apiKey = process.env.FLUIDSTACK_API_KEY;
+
+if (!apiKey) {
+    throw new Error('FLUIDSTACK_API_KEY environment variable is not set.');
+}
+
+...
+```
+
+```ts TypeScript SDK
+import { FluidStackApiClient } from "fluidstack";
+import dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config();
+
+// Get the API key from the environment variable
+const apiKey = process.env.FLUIDSTACK_API_KEY;
+
+if (!apiKey) {
+    throw new Error('FLUIDSTACK_API_KEY environment variable is not set.');
+}
+
+...
 ```
 </CodeBlocks>
+
 <Warning>
   If your `.env` file is inside a git repository, make sure that it's added to the [`.gitignore`](https://git-scm.com/docs/gitignore) file for that repository.
 </Warning>

--- a/fern/docs/pages/get-started/api-overview.mdx
+++ b/fern/docs/pages/get-started/api-overview.mdx
@@ -16,7 +16,7 @@ An **API key** is required for authentication to use the FluidStack API. Your AP
 
 [View, add, and delete your API keys](/dashboard/api-keys) from the FluidStack Dashboard.
 
-<Warning>
+<Warning title="Warning">
   Keep your API keys secure! Treat them like you would any other password. Do not share them with others, or in public repositories such as in GitHub. 
 </Warning>
 
@@ -130,6 +130,6 @@ if (!apiKey) {
 ```
 </CodeBlocks>
 
-<Warning>
+<Warning title="Warning">
   If your `.env` file is inside a git repository, make sure that it's added to the [`.gitignore`](https://git-scm.com/docs/gitignore) file for that repository.
 </Warning>

--- a/fern/docs/pages/get-started/home.mdx
+++ b/fern/docs/pages/get-started/home.mdx
@@ -5,30 +5,30 @@ subtitle: Get started using FluidStack's GPU instances
 
 <Cards>
     <Card 
-        title="Quickstart"
-        icon="fa-regular fa-play" 
-        href="/get-started/quickstart" 
+        title='Quickstart'
+        icon='fa-regular fa-play' 
+        href='/get-started/quickstart' 
     >
         Learn how to create, access, and terminate your first instance
     </Card>
     <Card
-        title="Programmatic Instance Management"
-        icon="fa-regular fa-book" 
-        href="/instances/manage/programmatic"
+        title='Programmatic Instance Management'
+        icon='fa-regular fa-book' 
+        href='/instances/manage/programmatic'
     >
-        Examples of how to use the FluidStack API in Python
+        Examples of how to use the FluidStack API in Python and TypeScript
     </Card>
     <Card 
-      title="Authentication" 
-      icon="fa-solid fa-key" 
-      href="/get-started/api-overview#authentication" 
+      title='Authentication' 
+      icon='fa-solid fa-key' 
+      href='/get-started/api-overview#authentication' 
     >
         How to authenticate with our API
     </Card>
     <Card 
-        title="API Reference" 
-        icon="fa-solid fa-code" 
-        href="/api-reference" 
+        title='API Reference' 
+        icon='fa-solid fa-code' 
+        href='/api-reference' 
     >
         Learn about the FluidStack API endpoints
     </Card>

--- a/fern/docs/pages/get-started/quickstart.mdx
+++ b/fern/docs/pages/get-started/quickstart.mdx
@@ -30,7 +30,7 @@ In this step, you will create an instance with the following configuration and o
 |------------------|-----------|-----------|----------|-------------------|-----------------
 | RTX_A6000_48GB   | 1         | 16        | 59GB     | 425 GB            | Ubuntu 20.04 LTS
 
-<Note>
+<Note title="Note">
   If you prefer, you can use a different [instance configuration](/instances/configurations) and/or [operating system](/instances/operating-systems).
 </Note>
 
@@ -47,7 +47,7 @@ curl -X POST https://platform.fluidstack.io/instances \
 }'
 ```
 
-<Warning>The `$` and `>` characters are not intended to be copied.</Warning>
+<Warning title="Warning">The `$` and `>` characters are not intended to be copied.</Warning>
 
 Paste the command to a location where you can edit its text in plaintext format, such as a code editor. Replace the text `<api_key>` with your API key, and `my_ssh_key` with the name of an SSH key on your account. 
 
@@ -63,7 +63,7 @@ If your request succeeds, the endpoint will respond with the created instance's 
 ```
 Take note of the `id` of your instance for the next step.
 
-<Note>
+<Note title="Note">
 Did you notice that the cURL command you sent did not specify an `operating_system_label`? 
 
 When the instance name is not specified, a randomized string is used. When the operating system is not specified, a default value is used. The only values you're required to specify when creating an instance are the instance `gpu_type`, and `ssh_key`.
@@ -120,7 +120,7 @@ Once the instance's status is `running`, you can connect to it using SSH. Use th
 
 <Markdown src='../../snippets/connect-with-ssh.mdx' />
 
-<Note>The first time you connect to your instance, you will see a message that says "The authenticity of host `x.x.x.x` can't be established ... Are you sure you want to continue connecting". This is normal for the first connection. Type `yes` and press `Enter`.</Note>
+<Note title="Note">The first time you connect to your instance, you will see a message that says "The authenticity of host `x.x.x.x` can't be established ... Are you sure you want to continue connecting". This is normal for the first connection. Type `yes` and press `Enter`.</Note>
 
 When you have successfully logged in, notice that your command prompt has changed. All commands that you enter into this command prompt are executed on your instance.
 

--- a/fern/docs/pages/get-started/quickstart.mdx
+++ b/fern/docs/pages/get-started/quickstart.mdx
@@ -11,7 +11,7 @@ This FluidStack API tutorial leads you through the following steps:
 2. [Access your instance](#access-your-instance) using an SSH client and your SSH key.
 3. [Terminate your instance](#terminate-your-instance).
 
-<Tip>If you'd rather use the FluidStack Dashboard UI to manage instances instead of the API, see: [Dashboard - Instances](/dashboard/instances).</Tip>
+<Tip title='Tip'>If you'd rather use the FluidStack Dashboard UI to manage instances instead of the API, see: [Dashboard - Instances](/dashboard/instances).</Tip>
 
 ## Prerequisites
 
@@ -49,16 +49,6 @@ curl -X POST https://platform.fluidstack.io/instances \
 
 <Warning>The `$` and `>` characters are not intended to be copied.</Warning>
 
-{/* If you have multiple SSH keys you'd like to associate with this instance, provide a comma-separated list in the cURL command:
-
-```bash Multiple SSH keys example {2-4}
-    "ssh_keys": [
-      "my_key1",
-      "my_key2",
-      "my_key3"
-    ]
-``` */}
-
 Paste the command to a location where you can edit its text in plaintext format, such as a code editor. Replace the text `<api_key>` with your API key, and `my_ssh_key` with the name of an SSH key on your account. 
 
 If your request succeeds, the endpoint will respond with the created instance's `id`, `name`, `gpu_type`, and `operating_system_label`:
@@ -76,14 +66,14 @@ Take note of the `id` of your instance for the next step.
 <Note>
 Did you notice that the cURL command you sent did not specify an `operating_system_label`? 
 
-When the operating system is not specified, a default value is used. The only values you're required to specify when creating an instance are the instance `name`, `gpu_type`, and `ssh_key`.
+When the instance name is not specified, a randomized string is used. When the operating system is not specified, a default value is used. The only values you're required to specify when creating an instance are the instance `gpu_type`, and `ssh_key`.
 </Note>
 
 ### Check the status of your instance
 
 Request the instance's status using the [List user instances](/api-reference/instances/list) endpoint:
 
-<EndpointRequestSnippet endpoint="GET /instances" />
+<EndpointRequestSnippet endpoint='GET /instances' />
 
 Initially, the instance's `status` will be `pending`. Once the instance is created and available, its `status` will update to `running` and FluidStack will assign it an IP address.
 
@@ -128,7 +118,7 @@ Locate the instance object with the `id` of your newly created instance. Take no
 
 Once the instance's status is `running`, you can connect to it using SSH. Use the private key that corresponds to the public key you used when creating the SSH key for this instance, and the `username` and `ip_address` you noted in the previous step. 
 
-<Markdown src="../../snippets/connect-with-ssh.mdx" />
+<Markdown src='../../snippets/connect-with-ssh.mdx' />
 
 <Note>The first time you connect to your instance, you will see a message that says "The authenticity of host `x.x.x.x` can't be established ... Are you sure you want to continue connecting". This is normal for the first connection. Type `yes` and press `Enter`.</Note>
 
@@ -140,11 +130,11 @@ When you're ready to close your connection and log out from the instance, type `
 
 To terminate your instance, first close your SSH connection, then call the API using the cURL command below. Replace the text `instance_id` in the endpoint's path with the `id` you received when you created the endpoint, and `<api_key>` with your API key.
 
-<EndpointRequestSnippet endpoint="DELETE /instances/:instance_id" />
+<EndpointRequestSnippet endpoint='DELETE /instances/:instance_id' />
 
 Example:
 
-```bash title="Example request"
+```bash title='Example request'
   curl -X DELETE https://platform.fluidstack.io/instances/i-1234567890 \
   -H "api-key: api_key_j123MyFakeAPIKey"
 ```

--- a/fern/docs/pages/instances/configurations.mdx
+++ b/fern/docs/pages/instances/configurations.mdx
@@ -14,5 +14,5 @@ The endpoint returns a list of configuration objects, as shown in this example r
 
 When you [create an instance](/api-reference/instances/create), you must specify a value for `gpu_type`. The value you specify for `gpu_count` determines the CPU count, as well as the RAM and NVME storage sizes.
 
-<Note>If you do not provide a value for `gpu_count` when creating an instance, `1` is used as the default.</Note>
+<Note title="Note">If you do not provide a value for `gpu_count` when creating an instance, `1` is used as the default.</Note>
 

--- a/fern/docs/pages/instances/configurations.mdx
+++ b/fern/docs/pages/instances/configurations.mdx
@@ -5,12 +5,12 @@ A configuration consists of the specific GPU, CPU, and storage settings for an i
 To see available configurations, call the [List available configurations](/api-reference/configurations/list) endpoint.
 
 Example request:
-<EndpointRequestSnippet endpoint="GET /list_available_configurations" />
+<EndpointRequestSnippet endpoint='GET /list_available_configurations' />
 
 Make sure to replace the `<api_key>` with your own [API key](/get-started/api-overview#authentication).
 
 The endpoint returns a list of configuration objects, as shown in this example response:
-<EndpointResponseSnippet endpoint="GET /list_available_configurations" />
+<EndpointResponseSnippet endpoint='GET /list_available_configurations' />
 
 When you [create an instance](/api-reference/instances/create), you must specify a value for `gpu_type`. The value you specify for `gpu_count` determines the CPU count, as well as the RAM and NVME storage sizes.
 

--- a/fern/docs/pages/instances/manage/create.mdx
+++ b/fern/docs/pages/instances/manage/create.mdx
@@ -1,5 +1,5 @@
 ---
-subtitle: How to create an instance with the FluidStackAPI
+subtitle: How to create an instance with the FluidStack API
 ---
 
 ## Steps
@@ -19,16 +19,16 @@ Retrieve the `gpu_type` of the desired configuration, and the `label` of the des
 Call the [Create a new instance](/api-reference/instances/create) endpoint to deploy an instance. 
 
 Example:
-<EndpointRequestSnippet endpoint="POST /instances" />
+<EndpointRequestSnippet endpoint='POST /instances' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" />
+<Markdown src='../../../snippets/api-key-header.mdx' />
 
 The following values are required in the JSON body of your request:
-- a custom `name` for the instance
 - the`gpu_type` (Select an option from the `gpu_model` field of your desired [Configuration](/instances/configurations).)
 - the `ssh_key_name` from an SSH key added to your FluidStack account
 
 These values are optional:
+- a custom `name` for the instance (Default: a randomized string)
 - `gpu_count` (Default: `1`)
 - `operating_system_label` (Select an option from the `label` field of your desired [Operating Systems](/instances/operating-systems). Default: `ubuntu_20_04_lts_nvidia`)
 
@@ -36,7 +36,7 @@ These values are optional:
 
 If the instance is successfully created, the endpoint will respond with a status code of `201`. The response body should contain a JSON object similar to this:
 
-<EndpointResponseSnippet endpoint="POST /instances" />
+<EndpointResponseSnippet endpoint='POST /instances' />
 
 </Steps>
 

--- a/fern/docs/pages/instances/manage/get.mdx
+++ b/fern/docs/pages/instances/manage/get.mdx
@@ -1,16 +1,16 @@
 ---
-subtitle: How to view an existing instance with the FluidStackAPI
+subtitle: How to view an existing instance with the FluidStack API
 ---
 
-Call the [Get user instance](/api-reference/instances/get) endpoint:
+Call the [Fetch a single user instance](/api-reference/instances/get) endpoint:
 
-<EndpointRequestSnippet endpoint="GET /instances/:instance_id" />
+<EndpointRequestSnippet endpoint='GET /instances/:instance_id' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" />
+<Markdown src='../../../snippets/api-key-header.mdx' />
 
 Example response:
 
-<EndpointResponseSnippet endpoint="GET /instances/:instance_id" />
+<EndpointResponseSnippet endpoint='GET /instances/:instance_id' />
 
 If your request succeeds, the endpoint will respond with a JSON containing one object.
 

--- a/fern/docs/pages/instances/manage/list.mdx
+++ b/fern/docs/pages/instances/manage/list.mdx
@@ -1,16 +1,16 @@
 ---
-subtitle: How to view your existing instances with the FluidStackAPI
+subtitle: How to view your existing instances with the FluidStack API
 ---
 
 Call the [List user instances](/api-reference/instances/list) endpoint:
 
-<EndpointRequestSnippet endpoint="GET /instances" />
+<EndpointRequestSnippet endpoint='GET /instances' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" />
+<Markdown src='../../../snippets/api-key-header.mdx' />
 
 Example response:
 
-<EndpointResponseSnippet endpoint="GET /instances" />
+<EndpointResponseSnippet endpoint='GET /instances' />
 
 If your request succeeds, the endpoint will respond with a JSON array containing one or more objects.
 

--- a/fern/docs/pages/instances/manage/overview.mdx
+++ b/fern/docs/pages/instances/manage/overview.mdx
@@ -6,4 +6,4 @@ In this section, learn how to use our API to manage your instances.
 - How to [terminate instances](./terminate-instances)
 - [Programmmatic instance management](./programmatic)
 
-<Tip>To learn how to manage instances through the FluidStack Dashboard UI instead of the API, see: [Dashboard - Instances](/dashboard/instances).<br /><br />To learn how to use our client SDKs to manage instances, see: [SDKs](/sdks).</Tip>
+<Tip title="Tip">To learn how to manage instances through the FluidStack Dashboard UI instead of the API, see: [Dashboard - Instances](/dashboard/instances).<br /><br />To learn how to use our client SDKs to manage instances, see: [SDKs](/sdks).</Tip>

--- a/fern/docs/pages/instances/manage/programmatic.mdx
+++ b/fern/docs/pages/instances/manage/programmatic.mdx
@@ -1,299 +1,582 @@
 ---
-description: This page contains example Python scripts to demonstrate how the FluidStack API can be used to manage instances programmatically.
+description: This page contains example scripts to demonstrate how the FluidStack API can be used to manage instances programmatically.
 ---
 
-The Python scripts on this page demonstrates how the [FluidStack API](/api-reference) can be used to manage instances programmatically. 
-
-You can choose to use Python only, or you can use our [Python SDK](/sdks/python/overview). 
+The Python and TypeScript scripts on this page demonstrates how the [FluidStack API](/api-reference) can be used to manage instances programmatically, with or without using one of our SDKs. 
 
 ## Prerequisites
-  - An [API key](/dashboard/api-keys)
-  - A [public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair)
-  - Basic familiarity with Python; Python 3+ installed
 
-## Script overview
+- An [API key](/dashboard/api-keys)
+- A [public/private key pair](/ssh/use-ssh-keys#generate-a-publicprivate-key-pair)
+- (for Python) Basic familiarity with Python; Python 3+ installed
+- (for TypeScript) Basic familiarity with TypeScript; Node 18+ installed; a [way to run TypeScript code locally](https://nodejs.org/en/learn/getting-started/nodejs-with-typescript#running-typescript-code-in-nodejs)
+
+## Overview of example scripts
 
 <Tabs>
-  <Tab title="Python script">
-    <Steps>
-      ### Create an SSH key
+    <Tab title='Without SDK'>
+        <Steps>
+            ### Create an SSH key
 
-      The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create a SSH key named `python_ssh_key`. This SSH key is a copy of the public key that was read.
+            The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create an SSH key. This key will be named either `python_ssh_key` or `typescript_ssh_key` and is a copy of the public key that was read.
 
-      <Warning>
-        - If you already have an SSH key named `python_ssh_key`, change the script to use a different, unique name.
-        - If your public key is in a different location or filename, make sure to update this part of the script.
-      </Warning>
+            <Warning>
+                - If you already have an SSH key on your FluidStack account named `python_ssh_key` or `typescript_ssh_key`, change the script to use a different, unique name. Alternatively, delete the existing key. 
+                - If your public key is in a different location or filename, make sure to update that part of the script.
+            </Warning>
 
-      ### Create an instance
+            ### Create an instance
 
-      The script creates an instance by sending a request to the [Create a new instance](/api-reference/instances/create) endpoint.
-      
-      The API key is sent in the request as a header. A custom name for the instance, the GPU type, and the name of the SSH key to use for accessing the instance are sent in the JSON body of the request.
+            The script creates an instance by sending a request to the [Create a new instance](/api-reference/instances/create) endpoint.
+            
+            The API key is sent in the request as a header. A custom name for the instance, the GPU type, and the name of the SSH key to use for accessing the instance are sent in the JSON body of the request.
 
-      ### Check the instance status
+            ### Check the instance status
 
-      Initially, the instance's `status` is `pending`. The script repeatedly checks this `status` until it is `running` by sending requests to the [List user instances](/api-reference/instances/list) endpoint and parsing the response. 
+            Initially, the instance's `status` is `pending`. The script repeatedly checks this `status` until it is `running` by sending requests to the [Fetch a single user instances](/api-reference/instances/get) endpoint and parsing the response. 
 
-      This status-checking loop stops once the instance's `status` returns as `running`, or if its `status` indicates that it has been `terminated` or is otherwise unable to run.
+            This status-checking loop stops once the instance's `status` returns as `running`, or if its `status` indicates that it has been `terminated` or is otherwise unable to run.
 
-      ### Print the instance IP
+            ### Print the instance IP
 
-      Once the instance's status is `running`, the script prints the instance's IP address.
+            Once the instance's status is `running`, the script prints the instance's IP address.
 
-      ### Terminate the instance
+            ### Terminate the instance
 
-      Finally, the script uses the [Terminate an instance](/api-reference/instances/delete) endpoint to delete the instance. 
-    </Steps>
-  </Tab>
+            The script uses the [Terminate an instance](/api-reference/instances/delete) endpoint to delete the instance. 
 
-  <Tab title="Python SDK script">
-    <Steps>
-      ### Instantiate a client
-      
-      The script uses the FluidStack SDK to instantiate an API client, passing a valid API key. 
-      
-      The instantiated client is configured with the API key and base URL of the API server, which means you can make requests without manually providing that information every time. 
+            ### Delete the SSH key on the account
 
-      ### Create an SSH key
+            Finally, the script also deletes the public SSH key that was added to the account.
 
-      The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create a SSH key named `python_sdk_ssh_key`. This SSH key is a copy of the public key that was read.
+        </Steps>
+    </Tab>
 
-      <Warning>
-        - If you already have an SSH key named `python_sdk_ssh_key`, change the script to use a different, unique name.
-        - If your public key is in a different location or filename, make sure to update this part of the script.
-      </Warning>
+    <Tab title='With SDK'>
+        <Steps>
+            ### Instantiate a client
+            
+            The script uses the FluidStack SDK to instantiate an API client, passing a valid API key. 
+            
+            The instantiated client is configured with the API key and base URL of the API server, which means you can make requests without manually providing that information every time. 
 
-      ### Create an instance
+            ### Create an SSH key
 
-      The script creates an instance, using the `client.instances.create()` method.
+            The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create an SSH key. This key will be named either `python_sdk_ssh_key` or `typescript_sdk_ssh_key` and is a copy of the public key that was read.
 
-      A custom name for the instance, the GPU type, and the name of the SSH key to use for accessing the instance are provided to the method. The client handles sending the request to the [Create a new instance](/api-reference/instances/create) endpoint, using the API key provided when the client was instantiated.
+            <Warning>
+                - If you already have an SSH key on your FluidStack account named `python_sdk_ssh_key` or `typescript_sdk_ssh_key`, change the script to use a different, unique name. Alternatively, delete the existing key.
+                - If your public key is in a different location or filename, make sure to update that part of the script.
+            </Warning>
 
-      ### Check the instance status
+            ### Create an instance
 
-      Initially, the instance's `status` is `pending`. The script repeatedly checks this `status` until it is `running` using the `client.instances.list()` method and parsing the response. 
+            The script creates an instance, using the `client.instances.create()` method.
 
-      This status-checking loop stops once the instance's `status` returns as `running`, or if its `status` indicates that it has been `terminated` or is otherwise unable to run.
+            A custom name for the instance, the GPU type, and the name of the SSH key to use for accessing the instance are provided to the method. The client handles sending the request to the [Create a new instance](/api-reference/instances/create) endpoint, using the API key provided when the client was instantiated.
 
-      ### Print the instance IP
+            ### Check the instance status
 
-      Once the instance's status is `running`, the script prints the instance's IP address.
+            Initially, the instance's `status` is `pending`. The script repeatedly checks this `status` until it is `running` using the `client.instances.get()` method and parsing the response. 
 
-      ### Terminate the instance
+            This status-checking loop stops once the instance's `status` returns as `running`, or if its `status` indicates that it has been `terminated` or is otherwise unable to run.
 
-      Finally, the script terminates the created instance, using the `client.instances.delete()` method.
-    </Steps>
-  </Tab>
+            ### Print the instance IP
+
+            Once the instance's status is `running`, the script prints the instance's IP address.
+
+            ### Terminate the instance
+
+            The script terminates the created instance, using the `client.instances.delete()` method.
+
+            ### Delete the SSH key on the account
+
+            Finally, the script also deletes the public SSH key that was added to the account.
+
+        </Steps>
+    </Tab>
 </Tabs>
 
-## Example script
+## Example scripts
 
 <Markdown src='../../../snippets/api-security-warning.mdx' />
 
 <Tabs>
-  {/* PYTHON WITHOUT SDK VERSION */}
 
-  <Tab title="Python">
-    Before running this script, replace the `api_key` value on line 7 with your own. You must also [install the `requests` library](https://pypi.org/project/requests/) into your environment. 
+    {/* PYTHON WITHOUT SDK VERSION */}
+    <Tab title='Python'>
 
-    ```python maxLines=30 {12,34,60,83,86}
-    import requests
-    from pathlib import Path
-    import time
-    import json
+        Before you run this script, replace the `api_key` value on line 7 with your own. You must also [install the `requests` library](https://pypi.org/project/requests/) into your environment. 
 
-    base_url = 'https://platform.fluidstack.io/'
-    api_key = 'api_key_j123My_FakeAPIKey'
+<Warning title="Warning">
+    The scripts below are intended for learning purposes. Do not place your API key inside any file that might be shared with others, such as by being committed to a git repository. For information on using a `.env` file to safeguard your API key, see: [API Overview - Secure use of your API key](/get-started/api-overview/secure-use-of-your-api-key).
+</Warning>
 
-    # Set the API key in a header
-    headers = { 'api-key': api_key }
+```python maxLines=30 {7,15,37,60,78,81,91}
+import requests
+from pathlib import Path
+import time
+import json
 
-    # 1: Create an SSH key
-    print('Creating SSH key')
+base_url = 'https://platform.fluidstack.io/'
+api_key = 'api_key_j123My_FakeAPIKey'
 
-    # Read the public key from ~/.ssh/id_rsa.pub
-    public_key = Path.home().joinpath('.ssh', 'id_rsa.pub').read_text().strip() 
+# Set the API key in a header
+headers = {
+    'api-key': api_key,
+    'Content-Type': 'application/json'
+}
 
-    ssh_key_name = 'python_ssh_key'
+# 1: Create an SSH key
+print('Creating SSH key')
 
-    # Send POST request to /ssh_keys
-    response = requests.post(
-      base_url + 'ssh_keys',
-      headers=headers,
-      json={
+# Read the public key from ~/.ssh/id_rsa.pub
+public_key = Path.home().joinpath('.ssh', 'id_rsa.pub').read_text().strip() 
+
+ssh_key_name = 'python_ssh_key'
+
+# Send POST request to /ssh_keys
+response = requests.post(
+    base_url + 'ssh_keys',
+    headers=headers,
+    json={
         'name': ssh_key_name,
         'public_key': public_key
-      },
-    )
+    },
+)
 
-    # Print response body if the response status code is not OK
-    if not response.ok:
-      raise Exception('Could not create SSH key')
+# Print response body if the response status code is not OK
+if not response.ok:
+    raise Exception('Could not create SSH key')
 
-    # 2: Create an instance 
-    print('Creating instance')
+# 2: Create an instance 
+print('Creating instance')
 
-    gpu_type = 'RTX_A6000_48GB'
-    instance_name = 'python_test_instance'
-
-    # Send POST request to /instances
-    response = requests.post(
-      base_url + 'instances',
-      headers = headers,
-      json = {
-        'name': instance_name,
+# Send POST request to /instances
+created_instance = requests.post(
+    base_url + 'instances',
+    headers=headers,
+    json={
+        'name': 'python_test_instance',
+        'gpu_type': 'RTX_A6000_48GB',
         'ssh_key': ssh_key_name,
-        'gpu_type': gpu_type,
-      },
-    )
+    },
+)
 
-    print('Response: ' + json.dumps(response.json(), indent=2))
-    if not response.ok:
-      raise Exception('Could not create instance')
+print('Response: ' + json.dumps(created_instance.json(), indent=2))
+if not created_instance.ok:
+    raise Exception('Could not create instance')
 
-    instance_id = response.json()['id']
+instance_id = created_instance.json()['id']
 
-    status = 'pending'
-    print('Waiting for instance to start')
+status = 'pending'
+print('Waiting for instance to start')
 
-    # 3: Check the instance status
-    # Check status every 10 seconds, exit when status is 'running'
-    count = 1
-    while status != 'running':
-      if status != 'pending':
+# 3: Check the instance status using GET /instances/{instance_id}
+# Check status every 10 seconds, exit when status is 'running'
+count = 1
+while status != 'running':
+    if status != 'pending':
         print('Could not create instance')
         raise Exception('Could not create instance')
-      try:
-        # Send GET request to /instances
-        response = requests.get(base_url + 'instances', headers=headers)
-        instances = response.json()
-        instance = None
-        for instance in instances:
-          if instance['id'] == instance_id:
-            status = instance['status']
-            break
+    try:
+        # Send GET request to /instances/{instance_id}
+        response = requests.get(base_url + f'instances/{instance_id}', headers=headers)
+        instance = response.json()
         status = instance['status']
-      except Exception as e:
+    except Exception as e:
         print(e)
-      print(f'\t [{count}] Status: {status}')
-      time.sleep(10)
-      count += 1
+    print(f'\t [{count}] Status: {status}')
+    time.sleep(10)
+    count += 1
 
-    # 4: Print the instance IP
-    print('Instance IP address: ' + instance['ip_address'])
+# 4: Print the instance IP
+print('Instance IP address: ' + instance['ip_address'])
 
-    # 5: Terminate the instance
-    print('Terminating instance')
+# 5: Terminate the instance
+print('Terminating instance')
 
-    # Send DELETE request to /instances/{instance_id}
-    response = requests.delete(base_url + f'instances/{instance_id}', headers=headers)
-    if not response.ok:
-      print('Response: ' + json.dumps(response.json(), indent=2))
-      raise Exception('Could not delete instance')
-    print('Instance deleted')
-    ```
+# Send DELETE request to /instances/{instance_id}
+response = requests.delete(base_url + f'instances/{instance_id}', headers=headers)
+if not response.ok:
+    print('Response: ' + json.dumps(response.json(), indent=2))
+    raise Exception('Could not delete instance')
+print('Instance deleted')
+
+# 6: Delete the public SSH key that was added to the account
+response = requests.delete(base_url + f'ssh_keys/{ssh_key_name}', headers=headers)
+if not response.ok:
+    print('Response: ' + json.dumps(response.json(), indent=2))
+    raise Exception('Could not delete the SSH key')
+print('SSH key deleted')
+```
   </Tab>
 
-  {/* PYTHON SDK VERSION */}
-  <Tab title="Python SDK">
-    Before running this script, replace the `api_key` value on line 6 with your own. You must also [install the FluidStack SDK](/sdks/python/use-python-sdk#installation) into your environment.
+    {/* PYTHON SDK VERSION */}
+    <Tab title='Python SDK'>
 
-    ```python maxLines=30 title="Python SDK" {8,13,31,53,76,79}
-    from FluidStack.client import FluidStack
-    from FluidStack.core import ApiError
-    from pathlib import Path
-    import time
+        Before you run this script, replace the `api_key` value on line 6 with your own. You must also [install the FluidStack SDK](/sdks/python/use-python-sdk#installation) into your environment.
 
-    api_key = 'api_key = 'api_key_j123My_FakeAPIKey'
+```python maxLines=30 {6,8,13,31,51,70,73,87}
+from FluidStack.client import FluidStack
+from FluidStack.core import ApiError
+from pathlib import Path
+import time
 
-    # 1: Instantiate a client
-    client = FluidStack(
-      api_key = api_key
+api_key = 'api_key_j123My_FakeAPIKey'
+
+# 1: Instantiate a client
+client = FluidStack(
+    api_key=api_key
+)
+
+# 2: Create an SSH key
+print('Creating SSH key')
+
+# Read the public key from ~/.ssh/id_rsa.pub
+public_key = Path.home().joinpath('.ssh', 'id_rsa.pub').read_text().strip()
+
+ssh_key_name = 'python_sdk_ssh_key'
+
+# Send POST request to /ssh_keys
+try:
+    client.ssh_keys.create(
+        name=ssh_key_name,
+        public_key=public_key,
     )
+except ApiError as e:
+    print(f'SSH key creation failed: {e}')
+    raise
 
-    # 2: Create an SSH key
-    print('Creating SSH key')
+# 3: Create an instance 
+print('Creating instance')
 
-    # Read the public key from ~/.ssh/id_rsa.pub
-    public_key = Path.home().joinpath('.ssh', 'id_rsa.pub').read_text().strip() 
+# Send POST request to /instances
+try:
+    created_instance = client.instances.create(
+        name='python_sdk_test_instance',
+        gpu_type='RTX_A6000_48GB',
+        ssh_key=ssh_key_name,
+    )
+except ApiError as e:
+    print(f'Instance creation failed: {e}')
+    raise
 
-    ssh_key_name = 'python_sdk_ssh_key'
+print(f'Response: {created_instance}')
+instance_id = created_instance.id
+status = 'pending'
 
-    # Send POST request to /ssh_keys
-    try:
-      response = client.ssh_keys.create(
-        name = ssh_key_name,
-        public_key = public_key,
-      )
-    except ApiError as e:
-      print(f'SSH key creation failed: {e}')
-      raise
+print('Waiting for instance to start')
 
-    # 3: Create an instance 
-    print('Creating instance')
-
-    gpu_type = 'RTX_A6000_48GB'
-    instance_name = 'python_sdk_test_instance'
-
-    # Send POST request to /instances
-    try:
-      my_instance = client.instances.create(
-        name = instance_name,
-        gpu_type = gpu_type,
-        ssh_key = ssh_key_name,
-      )
-    except ApiError as e:
-      print(f'Instance creation failed: {e}')
-      raise
-
-    print(f'Instance created: {my_instance}')
-    status = 'pending'
-
-    print('Waiting for instance to start')
-
-    # 4: Check the instance status
-    # Check status every 10 seconds, exit when status is 'running'
-    count = 1
-    while status != 'running':
-      if status != 'pending':
+# 4: Check the instance status using client.instances.get()
+# Check status every 10 seconds, exit when status is 'running'
+count = 1
+while status != 'running':
+    if status != 'pending':
         print('Could not create instance')
         raise Exception('Could not create instance')
-      try:
-        # Send GET request to /instances
-        instances = client.instances.list()
-        for instance in instances:
-          if instance.id == my_instance.id:
-            status = instance.status
-            break
+    try:
+        # Send GET request to /instances/{instance_id}
+        instance = client.instances.get(instance_id)
         status = instance.status
-      except ApiError as e:
-        print(f'Listing instances failed: {e}')
+    except ApiError as e:
+        print(f'Getting instance status failed: {e}')
         raise
 
-      print(f'\t [{count}] Status: {status}')
-      time.sleep(10)
-      count += 1
+    print(f'\t [{count}] Status: {status}')
+    time.sleep(10)
+    count += 1
 
-    # 5: Print the instance IP
-    print(f'Instance IP address: {instance.ip_address}')
+# 5: Print the instance IP
+print(f'Instance IP address: {instance.ip_address}')
 
-    # 6: Terminate the instance
-    print('Terminating instance')
+# 6: Terminate the instance
+print('Terminating instance')
 
-    # Send DELETE request to /instances/{instance_id}
-    try: 
-      response = client.instances.delete(
-        instance_id = my_instance.id,
+# Send DELETE request to /instances/{instance_id}
+try:
+    client.instances.delete(
+        instance_id=instance_id
     )
-    except ApiError as e:
-      print(f'Instance termination failed: {e}')
-      raise
+except ApiError as e:
+    print(f'Instance termination failed: {e}')
+    raise
 
-    print('Instance deleted')
-    ```
+print('Instance deleted')
+
+# 7: Delete the public SSH key that was added to the account
+try:
+    client.ssh_keys.delete(
+        ssh_key_name=ssh_key_name
+    )
+except ApiError as e:
+    print(f'SSH key deletion failed: {e}')
+    raise
+```
+    </Tab>
+
+    {/* TYPESCRIPT WITHOUT SDK VERSION */}
+    <Tab title='TypeScript'>
+
+        Before you run this script, replace the `apiKey` value on line 5 with your own. 
+
+```ts maxLines=30 {5,36,53,73,106,109,120}
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const baseUrl = 'https://platform.fluidstack.io/';
+const apiKey = 'api_key_j123My_FakeAPIKey';
+
+// Set the API key in a header
+const headers = new Headers({
+    'api-key': apiKey,
+    'Content-Type': 'application/json',
+});
+
+interface Instance {
+    id: string;
+    status: string;
+    ip_address: string;
+}
+
+interface CreateInstanceResponse {
+    id: string;
+}
+
+// Utility function to fetch JSON data and assert its type
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return response.json() as Promise<T>;
+}
+
+async function main(): Promise<void> {
+    const publicKey = readFileSync(join(process.env.HOME || '', '.ssh', 'id_rsa.pub'), 'utf-8').trim();
+    const sshKeyName = 'typescript_ssh_key';
+
+    // 1: Create an SSH key
+    // Read the public key from ~/.ssh/id_rsa.pub
+    console.log('Creating SSH key');
+    try {
+        await fetchJson(`${baseUrl}ssh_keys`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+                name: sshKeyName,
+                public_key: publicKey,
+            }),
+        });
+    } catch (error) {
+        console.error('Error creating SSH key:', error);
+        return;
+    }
+
+    // 2: Create an instance
+    console.log('Creating instance');
+    let instanceId: string;
+    try {
+        const createdInstance = await fetchJson<CreateInstanceResponse>(`${baseUrl}instances`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+                name: 'typescript_test_instance',
+                ssh_key: sshKeyName,
+                gpu_type: 'RTX_A6000_48GB',
+            }),
+        });
+        instanceId = createdInstance.id;
+        console.log('Response:', JSON.stringify(createdInstance, null, 2));
+    } catch (error) {
+        console.error('Error creating instance:', error);
+        return;
+    }
+
+    // 3: Check the instance status
+    console.log('Waiting for instance to start');
+    let instance: Instance;
+    let status: string;
+    let count = 1;
+
+    try {
+        instance = await fetchJson<Instance>(`${baseUrl}instances/${instanceId}`, { headers });
+        status = instance.status;
+    } catch (error) {
+        console.error('Error retrieving instance by ID:', error);
+        return;
+    }
+
+    while (status !== 'running') {
+        if (status !== 'pending') {
+            console.error('Could not create instance. Status:', status);
+            return;
+        }
+
+        try {
+            instance = await fetchJson<Instance>(`${baseUrl}instances/${instanceId}`, { headers });
+            status = instance.status;
+        } catch (error) {
+            console.error('Error fetching instance:', error);
+            return;
+        }
+
+        console.log(`\t [${count}] Status: ${status}`);
+        await new Promise(resolve => setTimeout(resolve, 10000)); // Wait for 10 seconds
+        count += 1;
+    }
+
+    // 4: Print the instance IP
+    console.log('Instance IP address:', instance.ip_address);
+
+    // 5: Terminate the instance
+    try {
+        await fetch(`${baseUrl}instances/${instanceId}`, {
+            method: 'DELETE',
+            headers,
+        });
+        console.log('Instance deleted');
+    } catch (error) {
+        console.error('Error deleting instance:', error);
+    }
+
+    // 6: Delete the SSH key
+    try {
+        await fetch(`${baseUrl}ssh_keys/${sshKeyName}`, {
+            method: 'DELETE',
+            headers,
+        });
+        console.log('SSH key deleted');
+    } catch (error) {
+        console.error('Error deleting SSH key:', error);
+    }
+}
+
+main().catch(error => {
+    console.error('Error in main function', error);
+});
+
+```
+
   </Tab>
+
+  {/* TYPESCRIPT SDK VERSION */}
+  <Tab title='TypeScript SDK'>
+    Before you run this script, replace the `apiKey` value on line 5 with your own. You must also [install the FluidStack TypeScript SDK](/sdks/typescript/use-typescript-sdk#installation) into your environment.
+
+```ts maxLines=30 {5,9,12,29,45,78,81,89}
+import { FluidStackApiClient } from "fluidstack";
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const apiKey = 'api_key_j123My_FakeAPIKey';
+
+async function main() {
+
+    // 1: Instantiate a client
+    const client = new FluidStackApiClient({ apiKey });
+
+    // 2: Create an SSH key
+    // Read the public key from ~/.ssh/id_rsa.pub
+    const publicKey = readFileSync(join(process.env.HOME || '', '.ssh', 'id_rsa.pub'), 'utf-8').trim();
+    const sshKeyName = 'typescript_sdk_ssh_key';
+
+    console.log('Creating SSH key');
+  
+    try {
+        await client.sshKeys.create({
+            name: sshKeyName,
+            publicKey: publicKey,
+        });
+    } catch (error) {
+        console.error('Error creating SSH key:', error);
+        return;
+    }
+
+    // 3: Create an instance
+    console.log('Creating instance')
+    let instanceId: string;
+    try {
+        const createdInstance = await client.instances.create({
+            name: 'typescript_sdk_test_instance',
+            gpuType: 'RTX_A6000_48GB',
+            sshKey: sshKeyName,
+        });
+        instanceId = createdInstance.id;
+        console.log('Response:', createdInstance);
+    } catch (error) {
+        console.error('Error creating instance:', error);
+        return;
+    }
+
+    // 4: Check the instance status
+    console.log('Waiting for instance to start');
+    let instance;
+    let count = 1;
+
+    try {
+        instance = await client.instances.get(instanceId);
+    } catch (error) {
+        console.error('Error retrieving instance by ID:', error);
+        return;
+    }
+
+    let status = instance.status;
+
+    while (status !== 'running') {
+        if (status !== 'pending') {
+            console.error('Could not create instance. Status:', status);
+            return;
+        }
+
+        try {
+            instance = await client.instances.get(instanceId);
+            status = instance.status;
+        } catch (error) {
+            console.error('Error fetching instance status:', error);
+            return;
+        }
+
+        console.log(`\t [${count}] Status: ${status}`);
+        await new Promise(resolve => setTimeout(resolve, 10000)); // Wait for 10 seconds
+        count += 1;
+    }
+
+    // 5: Print the instance IP
+    console.log('Instance IP address:', instance.ipAddress);
+
+    // 6: Terminate the instance
+    try {
+        await client.instances.delete(instanceId);
+        console.log('Instance deleted');
+    } catch (error) {
+        console.error('Error deleting instance:', error);
+    }
+
+    // 7: Delete the SSH key
+    try {
+        await client.sshKeys.delete(sshKeyName);
+        console.log('SSH key deleted');
+    } catch (error) {
+        console.error('Error deleting SSH key:', error);
+    }
+}
+
+main().catch(error => {
+    console.error('Error in main function', error);
+});
+```
+  </Tab>
+
 </Tabs>
+
+## Cleanup
+
+The script creates and deletes an SSH key and instance on the account associated with the provided API key.
+
+In case you ran into any issues with the script, confirm that the instance was deleted. If it was not deleted, stop or delete it manually to avoid incurring charges.
+
+If the SSH key on the account created by the script was not deleted, you must remove it manually before you can run the script again. 
 
 ## What's next?
 

--- a/fern/docs/pages/instances/manage/programmatic.mdx
+++ b/fern/docs/pages/instances/manage/programmatic.mdx
@@ -20,7 +20,7 @@ The Python and TypeScript scripts on this page demonstrates how the [FluidStack 
 
             The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create an SSH key. This key will be named either `python_ssh_key` or `typescript_ssh_key` and is a copy of the public key that was read.
 
-            <Warning>
+            <Warning title="Warning">
                 - If you already have an SSH key on your FluidStack account named `python_ssh_key` or `typescript_ssh_key`, change the script to use a different, unique name. Alternatively, delete the existing key. 
                 - If your public key is in a different location or filename, make sure to update that part of the script.
             </Warning>
@@ -64,7 +64,7 @@ The Python and TypeScript scripts on this page demonstrates how the [FluidStack 
 
             The script reads the public key located at `~/.ssh/id_rsa.pub`, then sends a request to the [Create an SSH key](/api-reference/ssh-keys/create) endpoint to create an SSH key. This key will be named either `python_sdk_ssh_key` or `typescript_sdk_ssh_key` and is a copy of the public key that was read.
 
-            <Warning>
+            <Warning title="Warning">
                 - If you already have an SSH key on your FluidStack account named `python_sdk_ssh_key` or `typescript_sdk_ssh_key`, change the script to use a different, unique name. Alternatively, delete the existing key.
                 - If your public key is in a different location or filename, make sure to update that part of the script.
             </Warning>

--- a/fern/docs/pages/instances/manage/programmatic.mdx
+++ b/fern/docs/pages/instances/manage/programmatic.mdx
@@ -108,10 +108,6 @@ The Python and TypeScript scripts on this page demonstrates how the [FluidStack 
 
         Before you run this script, replace the `api_key` value on line 7 with your own. You must also [install the `requests` library](https://pypi.org/project/requests/) into your environment. 
 
-<Warning title="Warning">
-    The scripts below are intended for learning purposes. Do not place your API key inside any file that might be shared with others, such as by being committed to a git repository. For information on using a `.env` file to safeguard your API key, see: [API Overview - Secure use of your API key](/get-started/api-overview#secure-use-of-your-api-key).
-</Warning>
-
 ```python maxLines=30 {7,15,37,60,78,81,91}
 import requests
 from pathlib import Path

--- a/fern/docs/pages/instances/manage/programmatic.mdx
+++ b/fern/docs/pages/instances/manage/programmatic.mdx
@@ -109,7 +109,7 @@ The Python and TypeScript scripts on this page demonstrates how the [FluidStack 
         Before you run this script, replace the `api_key` value on line 7 with your own. You must also [install the `requests` library](https://pypi.org/project/requests/) into your environment. 
 
 <Warning title="Warning">
-    The scripts below are intended for learning purposes. Do not place your API key inside any file that might be shared with others, such as by being committed to a git repository. For information on using a `.env` file to safeguard your API key, see: [API Overview - Secure use of your API key](/get-started/api-overview/secure-use-of-your-api-key).
+    The scripts below are intended for learning purposes. Do not place your API key inside any file that might be shared with others, such as by being committed to a git repository. For information on using a `.env` file to safeguard your API key, see: [API Overview - Secure use of your API key](/get-started/api-overview#secure-use-of-your-api-key).
 </Warning>
 
 ```python maxLines=30 {7,15,37,60,78,81,91}

--- a/fern/docs/pages/instances/manage/stop-start.mdx
+++ b/fern/docs/pages/instances/manage/stop-start.mdx
@@ -1,16 +1,16 @@
 ---
-subtitle: How to stop and start an instance
+subtitle: How to stop and start an instance with the FluidStack API
 ---
 
-You can only stop an instance that has the `status` of `running`, and you can only start an instance that has the `status` of `stopped`.  The instance's `id` is required to stop or start it. To find the `id` and `status` of an instance, see [List instances](/instances/manage/list).
+You can only stop an instance that has the `status` of `running`, and you can only start an instance that has the `status` of `stopped`.  The instance's `id` is required to stop or start it. To find the `id` and `status` of an instance, see [List instances](/instances/manage/list) or [Fetch a single user instance](/instances/manage/get).
 
 ### Stop an instance
 
 Call the [Stop an instance](/api-reference/instances/stop) endpoint:
 
-<EndpointRequestSnippet endpoint="PUT /instances/:instance_id/stop" />
+<EndpointRequestSnippet endpoint='PUT /instances/:instance_id/stop' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" /> 
+<Markdown src='../../../snippets/api-key-header.mdx' /> 
 
 Also, replace the text `{instance_id}` in the endpoint's path with your instance's `id`. 
 
@@ -22,7 +22,7 @@ curl -X PUT https://platform.fluidstack.io/instances/i-1234567890/stop \
 
 Example response:
 
-<EndpointResponseSnippet endpoint="PUT /instances/:instance_id/stop" />
+<EndpointResponseSnippet endpoint='PUT /instances/:instance_id/stop' />
 
 If your request succeeds, the endpoint will respond with a status code of `200` and JSON object containing your instance's details, including its current `status`.
 
@@ -34,9 +34,9 @@ For further details, see the [API Reference](/api-reference/instances/stop).
 
 Call the [Start an instance](/api-reference/instances/start) endpoint:
 
-<EndpointRequestSnippet endpoint="PUT /instances/:instance_id/start" />
+<EndpointRequestSnippet endpoint='PUT /instances/:instance_id/start' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" /> 
+<Markdown src='../../../snippets/api-key-header.mdx' /> 
 
 Also, replace the text `{instance_id}` in the endpoint's path with your instance's `id`. 
 
@@ -48,7 +48,7 @@ curl -X PUT https://platform.fluidstack.io/instances/i-1234567890/start \
 
 Example response:
 
-<EndpointResponseSnippet endpoint="PUT /instances/:instance_id/start" />
+<EndpointResponseSnippet endpoint='PUT /instances/:instance_id/start' />
 
 If your request succeeds, the endpoint will respond with a status code of `200` and an JSON object containing your instance's details, including its current `status`. The instance `status` should show as either `pending` or `running`. 
 

--- a/fern/docs/pages/instances/manage/terminate.mdx
+++ b/fern/docs/pages/instances/manage/terminate.mdx
@@ -1,14 +1,14 @@
 ---
-subtitle: How to terminate an instance
+subtitle: How to terminate an instance with the FluidStack API
 ---
 
 The instance's `id` is required to terminate it. To find the `id` of an instance, see [List instances](/instances/manage/list).
 
 Call the [Terminate an instance](/api-reference/instances/delete) endpoint:
 
-<EndpointRequestSnippet endpoint="DEL /instances/:instance_id" />
+<EndpointRequestSnippet endpoint='DEL /instances/:instance_id' />
 
-<Markdown src="../../../snippets/api-key-header.mdx" /> 
+<Markdown src='../../../snippets/api-key-header.mdx' /> 
 
 Also, replace the text `{instance_id}` in the endpoint's path with your instance's `id`. 
 

--- a/fern/docs/pages/instances/operating-systems.mdx
+++ b/fern/docs/pages/instances/operating-systems.mdx
@@ -3,12 +3,12 @@
 To see available OS templates, call the [List available OS templates](/api-reference/templates/list) endpoint.
 
 Example request:
-<EndpointRequestSnippet endpoint="GET /list_available_os_templates" />
+<EndpointRequestSnippet endpoint='GET /list_available_os_templates' />
 
 Make sure to replace the `<api_key>` with your own [API key](/get-started/api-overview#authentication)
 
 The endpoint returns a list of operating systems, as shown in this example response:
-<EndpointResponseSnippet endpoint="GET /list_available_os_templates" />
+<EndpointResponseSnippet endpoint='GET /list_available_os_templates' />
 
 When you [create an instance](/api-reference/instances/create), you can optionally select an operating system template by specifying a value for `operating system label`. For this, use one of the values for `label` returned by this endpoint.
 

--- a/fern/docs/pages/instances/operating-systems.mdx
+++ b/fern/docs/pages/instances/operating-systems.mdx
@@ -12,7 +12,7 @@ The endpoint returns a list of operating systems, as shown in this example respo
 
 When you [create an instance](/api-reference/instances/create), you can optionally select an operating system template by specifying a value for `operating system label`. For this, use one of the values for `label` returned by this endpoint.
 
-<Note>If you do not provide a value for `operating_system_label` when creating an instance, `ubuntu_20_04_lts_nvidia` is used as the default.</Note>
+<Note title="Note">If you do not provide a value for `operating_system_label` when creating an instance, `ubuntu_20_04_lts_nvidia` is used as the default.</Note>
 
 ### List of OS templates
 

--- a/fern/docs/pages/instances/transfer-files/rsync.mdx
+++ b/fern/docs/pages/instances/transfer-files/rsync.mdx
@@ -8,7 +8,7 @@ Unlike `scp`, which copies entire files regardless of changes, `rsync` checks th
 
 `rsync` is usually available by default on Linux, Unix, and macOS systems. On Windows, you can use `rsync` by installing a Linux-like environment, such as [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) or [Cygwin](https://www.cygwin.com/install.html).
 
-<Warning title="Warning">
+<Warning title='Warning'>
   Files copied with `rsync` that already exist at the target location will be overwritten without confirmation. You can use the [--ignore-existing option](#prevent-overwrites) to prevent this behavior.
 </Warning>
 
@@ -17,7 +17,7 @@ Unlike `scp`, which copies entire files regardless of changes, `rsync` checks th
 Run the `rsync` command from a terminal on your local machine. Ensure this terminal is _not_ within an SSH session to the instance.
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" <source_path> <target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' <source_path> <target_path>/
 ```
 
 Prefix the instance's username and IP address to the source path for downloads and to the target path for uploads, followed by a colon:
@@ -28,7 +28,7 @@ ubuntu@192.0.2.0:/home/ubuntu/
 
 For the private key path, use the local path to the private key for the instance's SSH key. See: [How to use SSH keys](/ssh/use-ssh-keys).
 
-<Tip title="Tip">
+<Tip title='Tip'>
   If you have recently logged into the instance via SSH from your local machine, your credentials might be cached. In this case, you can omit the `-i` flag and the private key path. 
 </Tip>
 
@@ -47,11 +47,11 @@ The options `-avz` are commonly used for efficient and informative data transfer
 ## Transfer a file
 
 <Tabs>
-  <Tab title="Upload a file">
+  <Tab title='Upload a file'>
     To upload a file to an instance, use the following command:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" <source_file_path> <username>@<ip_address>:<target_dir_path>/
+rsync -avz -e 'ssh -i <private_key_path>' <source_file_path> <username>@<ip_address>:<target_dir_path>/
 ```
 
     ### Example
@@ -59,16 +59,16 @@ rsync -avz -e "ssh -i <private_key_path>" <source_file_path> <username>@<ip_addr
     Upload a file named `myfile` from the current directory of your local machine to the `/home/ubuntu/` directory on the instance:
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" myfile ubuntu@192.0.2.0:/home/ubuntu/
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' myfile ubuntu@192.0.2.0:/home/ubuntu/
 ```
 
   </Tab>
 
-  <Tab title="Download a file">
+  <Tab title='Download a file'>
     To download a file from an instance, use the following command:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" <username>@<ip_address>:<source_file_path> <target_dir_path>/
+rsync -avz -e 'ssh -i <private_key_path>' <username>@<ip_address>:<source_file_path> <target_dir_path>/
 ```
 
     ### Example
@@ -76,12 +76,12 @@ rsync -avz -e "ssh -i <private_key_path>" <username>@<ip_address>:<source_file_p
     Download a file named `myfile` from `/home/ubuntu/` on the instance to the current directory of your local machine:
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" ubuntu@192.0.2.0:/home/ubuntu/myfile ./
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' ubuntu@192.0.2.0:/home/ubuntu/myfile ./
 ```
   </Tab>
 </Tabs>
 
-<Warning title="Warning">
+<Warning title='Warning'>
   You can omit the trailing slash `/` for the target directory path. However, you must be cautious. If you specify a non-existent directory on the target _and_ omit the trailing slash, the source file will be copied with the directory name as the filename.
 
   **Example:** Transferring `myfile` to `ubuntu@192.0.2.0:/home/ubuntu/xyz` where the directory `/home/ubuntu/xyz` does not exist will result in `myfile` being copied to a _file_ named `xyz` at `/home/ubuntu/`. If you use `ubuntu@192.0.2.0:/home/ubuntu/xyz/` instead, `rsync` will create the `xyz` directory and copy `myfile` into it.
@@ -90,11 +90,11 @@ rsync -avz -e "ssh -i ~/.ssh/id_rsa" ubuntu@192.0.2.0:/home/ubuntu/myfile ./
 ## Transfer a directory
 
 <Tabs>
-  <Tab title="Upload a directory">
+  <Tab title='Upload a directory'>
     To upload a directory to an instance, use the following command:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" <source_dir_path> <username>@<ip_address>:<target_parent_dir_path>/
+rsync -avz -e 'ssh -i <private_key_path>' <source_dir_path> <username>@<ip_address>:<target_parent_dir_path>/
 ```
 
     If the directory already exists in the provided target parent directory on the instance, this synchronizes that directory with the local directory.
@@ -104,15 +104,15 @@ rsync -avz -e "ssh -i <private_key_path>" <source_dir_path> <username>@<ip_addre
     Upload a directory named `mydir` from your local machine to `/home/ubuntu/mydir` on the instance:
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" mydir ubuntu@192.0.2.0:/home/ubuntu/
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' mydir ubuntu@192.0.2.0:/home/ubuntu/
 ```
   </Tab>
 
-  <Tab title="Download a directory">
+  <Tab title='Download a directory'>
     To download a directory from an instance, use:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" <username>@<ip_address>:<source_dir_path> <target_dir_path>/
+rsync -avz -e 'ssh -i <private_key_path>' <username>@<ip_address>:<source_dir_path> <target_dir_path>/
 ```
 
     If the directory already exists at the provided target directory path on your local machine, this synchronizes that directory with the instance directory.
@@ -122,13 +122,13 @@ rsync -avz -e "ssh -i <private_key_path>" <username>@<ip_address>:<source_dir_pa
     Download a directory named `mydir` from `/home/ubuntu` on the instance to the current directory of your local machine:
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" ubuntu@192.0.2.0:/home/ubuntu/mydir ./
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' ubuntu@192.0.2.0:/home/ubuntu/mydir ./
 ```
 
   </Tab>
 </Tabs>
 
-<Note title="Note">
+<Note title='Note'>
   If the target parent directory path does not exist, `rsync` will create the parent directory and copy the source directory into it. 
 </Note>
 
@@ -141,7 +141,7 @@ In addition to `-avz` (the options described in the [Basic syntax](#basic-syntax
 To preview what files will be transferred without actually transferring them, use the `--dry-run` option:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --dry-run <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --dry-run <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 ### Progress bar
@@ -149,7 +149,7 @@ rsync -avz -e "ssh -i <private_key_path>" --dry-run <source_path> <username>@<ip
 To display progress information during the transfer, use the `--progress` option:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --progress <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --progress <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 ### Delete files on target
@@ -157,7 +157,7 @@ rsync -avz -e "ssh -i <private_key_path>" --progress <source_path> <username>@<i
 To delete files on the target that do not exist on the source, use the `--delete` option:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --delete <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --delete <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 This synchronizes the target directory with the source by removing any extra files that aren't in the source directory.
@@ -177,13 +177,13 @@ This continues from where the transfer was interrupted, without re-transferring 
 To limit the bandwidth used by `rsync`, use the `--bwlimit` option followed by the limit in kilobits per second (Kbps):
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --bwlimit=<rate_in_Kbps> <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --bwlimit=<rate_in_Kbps> <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 **Example**
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" --bwlimit=1000 /users/ada/mydir ubuntu@192.0.2.0:/home/ubuntu/mydir/
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' --bwlimit=1000 /users/ada/mydir ubuntu@192.0.2.0:/home/ubuntu/mydir/
 ```
 
 ### Exclude files
@@ -191,7 +191,7 @@ rsync -avz -e "ssh -i ~/.ssh/id_rsa" --bwlimit=1000 /users/ada/mydir ubuntu@192.
 To exclude certain files from being transferred, use the `--exclude` option:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --exclude '<string_to_exclude>' <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --exclude '<string_to_exclude>' <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 **Example**
@@ -199,7 +199,7 @@ rsync -avz -e "ssh -i <private_key_path>" --exclude '<string_to_exclude>' <sourc
 The following command excludes all `.log` files from the transfer:
 
 ```bash
-rsync -avz -e "ssh -i ~/.ssh/id_rsa" --exclude '*.log' /users/ada/mydir ubuntu@192.0.2.0:/home/ubuntu/mydir/
+rsync -avz -e 'ssh -i ~/.ssh/id_rsa' --exclude '*.log' /users/ada/mydir ubuntu@192.0.2.0:/home/ubuntu/mydir/
 ```
 
 ### Prevent overwrites
@@ -207,7 +207,7 @@ rsync -avz -e "ssh -i ~/.ssh/id_rsa" --exclude '*.log' /users/ada/mydir ubuntu@1
 By default, `rsync` overwrites existing files at the target without prompting for confirmation. To prevent this behavior, use the `--ignore-existing` option:
 
 ```bash
-rsync -avz -e "ssh -i <private_key_path>" --ignore-existing <source_path> <username>@<ip_address>:<target_path>/
+rsync -avz -e 'ssh -i <private_key_path>' --ignore-existing <source_path> <username>@<ip_address>:<target_path>/
 ```
 
 ## Additional resources

--- a/fern/docs/pages/instances/transfer-files/scp.mdx
+++ b/fern/docs/pages/instances/transfer-files/scp.mdx
@@ -8,7 +8,7 @@ If SSH is installed on your local machine, `scp` is typically included in most S
 
 Although `scp` is straightforward and user-friendly, it lacks advanced features such as delta transfers (which send only the changed parts of files), integrity checks, and the ability to resume interrupted transfers. It is best suited for quick, one-time transfers of small to medium-sized files, like configuration files, scripts, and smaller data sets. For larger transfers or directory synchronization, consider using [rsync](/instances/transfer-files/rsync).
 
-<Warning title="Warning">
+<Warning title='Warning'>
 Files copied with `scp` that already exist at the target location will be overwritten without confirmation.
 </Warning>
 
@@ -28,14 +28,14 @@ ubuntu@192.0.2.0:/home/ubuntu/
 
 For the private key path, use the local path to the private key for the instance's SSH key. See: [How to use SSH keys](/ssh/use-ssh-keys).
 
-<Tip title="Tip">
+<Tip title='Tip'>
   If you have recently logged into the instance via SSH from your local machine, your credentials might be cached. In this case, you can omit the `-i` flag and the private key path. 
 </Tip>
 
 ## Transfer a file
 
 <Tabs>
-  <Tab title="Upload a file">
+  <Tab title='Upload a file'>
 
     To upload a file to an instance, use the following command:
 
@@ -52,7 +52,7 @@ scp -i ~/.ssh/id_rsa myfile ubuntu@192.0.2.0:/home/ubuntu/
 ```
   </Tab>
 
-  <Tab title="Download a file">
+  <Tab title='Download a file'>
 
     To download a file from an instance, use the following command:
 
@@ -70,7 +70,7 @@ scp -i ~/.ssh/id_rsa ubuntu@192.0.2.0:/home/ubuntu/myfile ./
   </Tab>
 </Tabs>
 
-<Warning title="Warning">
+<Warning title='Warning'>
   You can omit the trailing slash `/` for the target directory path. However, you must be cautious. If you specify a non-existent directory on the target _and_ omit the trailing slash, the source file will be copied with the directory name as the filename.
 
   **Example:** Transferring `myfile` to `ubuntu@192.0.2.0:/home/ubuntu/xyz` where the directory `/home/ubuntu/xyz` does not exist will result in `myfile` being copied to a _file_ named `xyz` at `/home/ubuntu/`. If you use `ubuntu@192.0.2.0:/home/ubuntu/xyz/` instead, `scp` will exit without copying.
@@ -81,7 +81,7 @@ scp -i ~/.ssh/id_rsa ubuntu@192.0.2.0:/home/ubuntu/myfile ./
 To recursively copy a directory and its contents, use the `-r` flag followed by the directory path.
 
 <Tabs>
-  <Tab title="Upload a directory">
+  <Tab title='Upload a directory'>
 
     To upload a directory to an instance, use the following command:
 
@@ -98,7 +98,7 @@ scp -i ~/.ssh/id_rsa -r mydir ubuntu@192.0.2.0:/home/ubuntu/
 ```
   </Tab>
 
-  <Tab title="Download a directory">
+  <Tab title='Download a directory'>
 
     To download a directory from an instance, use the following command:
 
@@ -121,7 +121,7 @@ scp -i ~/.ssh/id_rsa -r ubuntu@192.0.2.0:/home/ubuntu/mydir ./
 ### Rename the transferred file
 
 <Tabs>
-  <Tab title="Rename a file during upload">
+  <Tab title='Rename a file during upload'>
 
     To upload a file and rename it at the target instance, use the following command:
 
@@ -137,7 +137,7 @@ scp -i ~/.ssh/id_rsa file1 ubuntu@192.0.2.0:/home/ubuntu/file2
 ```
   </Tab>
 
-  <Tab title="Rename a file during download">
+  <Tab title='Rename a file during download'>
 
     To download a file and rename it on your local machine, use the following command:
 
@@ -158,7 +158,7 @@ scp -i ~/.ssh/id_rsa ubuntu@192.0.2.0:/home/ubuntu/file1 ./file2
 ### Rename the transferred directory
 
 <Tabs>
-  <Tab title="Rename a directory during upload">
+  <Tab title='Rename a directory during upload'>
 
     To upload a directory and rename it on the target instance, use the following command:
 
@@ -175,7 +175,7 @@ scp -i ~/.ssh/id_rsa -r dir1 ubuntu@192.0.2.0:/home/ubuntu/dir2
 ```
   </Tab>
 
-  <Tab title="Rename a directory during download">
+  <Tab title='Rename a directory during download'>
 
     To download a directory and rename it on your local machine, use the following command:
 

--- a/fern/docs/pages/sdks/python/overview.mdx
+++ b/fern/docs/pages/sdks/python/overview.mdx
@@ -8,7 +8,7 @@ It includes the following features:
 
 - Type definitions for all request and response fields
 - Synchronous and [asynchronous clients](#async-client) powered by [httpx](https://www.python-httpx.org/)
-- Exception handling as subclasses of ApiError
+- [Exception handling](#exception-handling) as subclasses of ApiError
 - Configurable [timeouts](#timeouts)
 - Automatic [retries](#retries) with exponential backoff
 
@@ -20,22 +20,22 @@ The SDK exports an async client for making non-blocking calls to our API.
 from FluidStack.client import AsyncFluidStack
 
 client = AsyncFluidStack(
-    api_key = "<your_api_key>"
+    api_key = '<your_api_key>'
 )
 
 async def main() -> None:
     await client.ssh_keys.create(
-        name = "my_ssh_key_name",
-        public_key = "<public key>",
+        name = 'my_ssh_key_name',
+        public_key = '<public key>',
     )
 asyncio.run(main())
 ```
 
 ## Exception handling
 
-All errors thrown by the SDK will be subclasses of ApiError.
+All errors thrown by the SDK are subclasses of `ApiError`.
 
-```python 
+```python Example
 import FluidStack
 
 try:
@@ -94,8 +94,8 @@ from FluidStack.client import FluidStack
 
 client = FluidStack(...,
     http_client=httpx.Client(
-        proxies="http://my.test.proxy.example.com",
-        transport=httpx.HTTPTransport(local_address="0.0.0.0"),
+        proxies='http://my.test.proxy.example.com',
+        transport=httpx.HTTPTransport(local_address='0.0.0.0'),
     ),
 )
 ```

--- a/fern/docs/pages/sdks/python/use-python-sdk.mdx
+++ b/fern/docs/pages/sdks/python/use-python-sdk.mdx
@@ -8,6 +8,7 @@
 Our Python SDK is hosted at the [Python Package Index](https://pypi.org/project/fluidstack/) (PyPI). You can use any Python package manager, such as [pip](https://pip.pypa.io/en/stable/) or [poetry](https://python-poetry.org/docs/). 
 
 For example, you can add this dependency to your project's build file:
+
 ```python
 pip install fluidstack
 # or
@@ -22,7 +23,7 @@ Import `FluidStack` and instantiate a client with your API key:
 from FluidStack.client import FluidStack
 
 client = FluidStack(
-    api_key = "<your_api_key>"
+    api_key = '<your_api_key>'
 )
 ```
 
@@ -39,16 +40,21 @@ The SDK also provides code hints, type hints, parameter information, and other u
 For example, compare the tabs below:
 
 <CodeBlocks>
+
 ```python With the SDK
+...
 client.instances.create(
-  name="my_instance",
-  gpu_type="RTX_A6000_48GB",
-  ssh_key="my_ssh_key"
+  name='my_instance',
+  gpu_type='RTX_A6000_48GB',
+  ssh_key='my_ssh_key'
 )
+...
 ```
+
 ```python Without the SDK
+...
 requests.post(
-  api_url + "instances",
+  api_url + 'instances',
   headers = headers,
   json = {
       "name": "my_instance",
@@ -56,7 +62,9 @@ requests.post(
       "ssh_key": "my_ssh_key"
   }
 )
+...
 ```
+
 </CodeBlocks>
 
 You can see that instead of using `requests` or a similar module to send an HTTP request and including the endpoint path and headers each time, the FluidStack client simplifies the request for you. 
@@ -78,126 +86,169 @@ print(client.instances.list())
 ```
 
 Or you could loop through the list and print only the name and status for each instance:
+
 ```python Print each instance name and status
 my_instances = client.instances.list()
 for instance in my_instances:
-    print(f"Instance: {instance.name}, Status: {instance.status}")
+    print(f'Instance: {instance.name}, Status: {instance.status}')
 ```
+
+See the [Programmatic Instance Management](/instances/manage/programmatic) tutorial for more information on using Python, TypeScript, and their respective SDKs.
 
 ## Instances 
 
 <Tabs>
-  <Tab title="List user instances">
-    ```python 
-      client.instances.list()
-    ```
+  <Tab title='List user instances'>
+
+```python 
+  client.instances.list()
+```
+
     **Parameters: None.**
   </Tab>
 
-  <Tab title="Create an instance">
-    ```python 
-    client.instances.create(
-      name="my_instance",
-      gpu_type="my_gpu_type",
-      ssh_key="my_ssh_key",
-      gpu_count="my_gpu_count"
-      operating_system_label="my_os_label"
-    )
-    ```
+  <Tab title='Create an instance'>
+
+```python 
+client.instances.create(
+  name='my_instance_name',
+  gpu_type='RTX_A6000_48GB',
+  ssh_key='my_ssh_key',
+  gpu_count='2'
+  operating_system_label='ubuntu_20_04_lts_nvidia',
+  region='NORWAY'
+)
+
+```
     | parameter              | type   | required | default                 |
     |------------------------|--------|----------|-------------------------|
-    | name                   | string |     yes  |   n/a                   |
     | gpu_type               | string |     yes  |   n/a                   |
     | ssh_key                | string |     yes  |   n/a                   |
+    | name                   | string |     no   |   randomized string     |
     | gpu_count              | string |     no   |    1                    |
     | operating_system_label | string |     no   | ubuntu_20_04_lts_nvidia |
+    | region                 | string |     no   | none                    |
 
   </Tab>
 
-  <Tab title="Stop an instance">
-    ```python 
-    client.instances.stop(
-        instance_id="instance_id",
-    )
-    ```
+  <Tab title='Fetch an instance'>
+
+```python 
+client.instances.get(
+    instance_id='instance_id',
+)
+```
+
     | parameter              | type   | required |
     |------------------------|--------|----------|
     | instance_id            | string |     yes  |
+
+  </Tab>
+
+  <Tab title='Stop an instance'>
+
+```python 
+client.instances.stop(
+    instance_id='instance_id',
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | instance_id            | string |     yes  |
+
   </Tab>
   
-  <Tab title="Start an instance">
-    ```python
-    client.instances.start(
-        instance_id="instance_id",
-    )
-    ```
+  <Tab title='Start an instance'>
+
+```python
+client.instances.start(
+    instance_id='instance_id',
+)
+```
+
     | parameter              | type   | required |
     |------------------------|--------|----------|
     | instance_id            | string |     yes  |
   </Tab>
 
-  <Tab title="Terminate an instance">
-    ```python 
-    client.instances.delete(
-        instance_id="instance_id",
-    )
-    ```
+  <Tab title='Terminate an instance'>
+
+```python 
+client.instances.delete(
+    instance_id='instance_id',
+)
+```
+
     | parameter              | type   | required |
     |------------------------|--------|----------|
     | instance_id            | string |     yes  |
   </Tab>
+
 </Tabs>
 
 ## SSH Keys
 
 <Tabs>
-  <Tab title="List SSH keys">
-    ```python 
-      client.ssh_keys.list()
-    ```
+  <Tab title='List SSH keys'>
+
+```python 
+  client.ssh_keys.list()
+```
+
     **Parameters: None.**
   </Tab>
 
-  <Tab>
-    ```python Add an SSH key
-    client.ssh_keys.create(
-      name="my_ssh_key", 
-      public_key="my_public_key" 
-    )
-    ```
+  <Tab title='Add an SSH key'>
+
+```python Add an SSH key
+client.ssh_keys.create(
+  name='my_ssh_key', 
+  public_key='my_public_key' 
+)
+```
+
     | parameter              | type   | required |
     |------------------------|--------|----------|
     | name                   | string |     yes  |
     | public_key             | string |     yes  |
   </Tab>
 
-  <Tab title="Delete an SSH key">
-    ```python 
-    client.ssh_keys.delete(
-        ssh_key_name="my_ssh_key",
-    )
-    ```
+  <Tab title='Delete an SSH key'>
+
+```python 
+client.ssh_keys.delete(
+    ssh_key_name='my_ssh_key',
+)
+```
+
     | parameter              | type   | required |
     |------------------------|--------|----------|
     | ssh_key_name           | string |     yes  |
+
   </Tab>
 </Tabs>
-
 
 ## List available configurations and operating system templates
 
 <Tabs>
-  <Tab title="Configurations">
-    ```python 
-    client.configurations.list()
-    ```
+  <Tab title='Configurations'>
+
+```python 
+client.configurations.list()
+```
+
     **Parameters: None.**
+
   </Tab>
 
-  <Tab title="OS Templates">
-  ```python 
-  client.templates.list()
-  ```
+  <Tab title='OS Templates'>
+
+```python 
+client.templates.list()
+```
+
     **Parameters: None.**
+
   </Tab>
 </Tabs>

--- a/fern/docs/pages/sdks/typescript/overview.mdx
+++ b/fern/docs/pages/sdks/typescript/overview.mdx
@@ -11,8 +11,8 @@ It includes the following features:
 - Ability to [abort requests](#abort-requests)
 - [Runtime compatibility](#runtime-compatibility)
 - Ability to [customize the fetch client](#customize-the-fetch-client)
-- Configurable [timeouts](#timeouts)
 - Automatic [retries](#retries) with exponential backoff
+- Configurable [timeouts](#timeouts)
 
 ## Request and response types
 
@@ -57,7 +57,7 @@ const response = await fluidStackApi.create(..., {
 controller.abort(); // aborts the request
 ```
 
-# Runtime compatibility
+## Runtime compatibility
 
 The SDK defaults to `node-fetch` but will use the global `fetch` client if present.
 

--- a/fern/docs/pages/sdks/typescript/overview.mdx
+++ b/fern/docs/pages/sdks/typescript/overview.mdx
@@ -1,0 +1,114 @@
+---
+subtitle: About the FluidStack Software Development Kit for TypeScript applications
+---
+
+FluidStack's TypeScript SDK assists in developing applications in TypeScript using the FluidStack API.
+
+It includes the following features:
+
+- TypeScript interfaces for all [request and response types](#request-and-response-types)
+- [Exception handling](#exception-handling) as subclasses of FluidStackApiError
+- Ability to [abort requests](#abort-requests)
+- [Runtime compatibility](#runtime-compatibility)
+- Ability to [customize the fetch client](#customize-the-fetch-client)
+- Configurable [timeouts](#timeouts)
+- Automatic [retries](#retries) with exponential backoff
+
+## Request and response types
+
+The SDK exports all request and response types as TypeScript interfaces. Import them with the following namespace:
+
+```ts Example
+import { FluidStackApi } from "fluidstack";
+
+const request: FluidStackApi.CreateInstanceRequest = {
+    ...
+};
+const response = await fluidStackApi.create(request);
+```
+
+## Exception handling
+
+When the API returns a non-success status code (4xx or 5xx response), a subclass of `FluidStackApiError` is thrown.
+
+```ts Example
+import { FluidStackApiError } from 'fluidstack';
+
+try {
+    await fluidStackApi.create(...);
+} catch (err) {
+    if (err instanceof FluidStackApiError) {
+        console.log(err.statusCode);
+        console.log(err.message);
+        console.log(err.body);
+    }
+}
+```
+
+## Abort requests
+
+Abort requests at any point by passing in an abort signal.
+
+```ts Example
+const controller = new AbortController();
+const response = await fluidStackApi.create(..., {
+    abortSignal: controller.signal
+});
+controller.abort(); // aborts the request
+```
+
+# Runtime compatibility
+
+The SDK defaults to `node-fetch` but will use the global `fetch` client if present.
+
+The SDK works in the following runtimes:
+
+- Node.js 18+
+- Vercel
+- Cloudflare Workers
+- Deno v1.25+
+- Bun 1.0+
+- React Native
+
+## Customize the fetch client
+
+The SDK provides a way for your to customize the underlying HTTP client or `fetch` function. If you're running in an unsupported environment, this provides a way for you to break the glass and ensure that the SDK works.
+
+```ts Example
+import { FluidStackApiClient } from 'fluidstack';
+
+const fluidStackApi = new FluidStackApiClient({
+    ...
+    fetcher: // provide your implementation here
+});
+```
+
+## Advanced
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long as the request is deemed retriable and the number of retry attempts has not grown larger than the configured retry limit (default: `2`).
+
+A request is deemed retriable when any of the following HTTP status codes is returned:
+
+- 408 (Timeout)
+- 429 (Too Many Requests)
+- 5XX (Internal Server Errors)
+
+Use the `maxRetries` request option to configure this behavior.
+
+```ts Example
+const response = await fluidStackApi.create(..., {
+    maxRetries: 0 // override maxRetries at the request level
+});
+```
+
+### Timeouts
+
+The SDK defaults to a 60-second timeout. Use the `timeoutInSeconds` option to configure this behavior.
+
+```ts Example
+const response = await fluidStackApi.create(..., {
+    timeoutInSeconds: 30 // override timeout to 30s
+});
+```

--- a/fern/docs/pages/sdks/typescript/use-typescript-sdk.mdx
+++ b/fern/docs/pages/sdks/typescript/use-typescript-sdk.mdx
@@ -1,0 +1,277 @@
+## Prerequisites
+- An [API key](/dashboard/api-keys)
+- Familiarity with command-line tools
+- Basic familiarity with TypeScript and Node.js; Node 18+ installed
+
+## Installation
+
+Our TypeScript SDK is hosted at [NPM](https://www.npmjs.com/package/fluidstack). 
+
+Use `npm` or `yarn` to install it to your project:
+
+```bash
+npm install fluidstack
+```
+
+```bash
+yarn add fluidstack
+```
+
+## Instantiate a client
+
+Import `FluidStackApiClient` and instantiate a TypeScript client with your API key:
+
+```ts Example
+import { FluidStackApiClient } from 'fluidstack';
+
+const client = new FluidStackApiClient({
+    apiKey: '<your_api_key>'
+});
+```
+
+Now you can use the client to consume the API from your TypeScript application.
+
+<Markdown src='../../../snippets/api-security-warning.mdx' />
+
+## Use the FluidStack TypeScript client in your app
+
+The FluidStack TypeScript client simplifies making API requests. It stores the API key that you used to instantiate it, and it already knows our API server's base URL, so you can omit those details in your requests.
+
+The SDK also provides code hints, type hints, parameter information, and other useful functions to speed up development. 
+
+For example, compare the tabs below:
+
+<CodeBlocks>
+
+```ts With the TypeScript SDK
+client.instances.create(
+  gpuType='RTX_A6000_48GB',
+  sshKey='mySSHKey'
+)
+```
+
+```ts Without the SDK
+  await fetch('https://platform.fluidstack.io/', {
+    method: 'POST',
+    headers: {
+      'api-key': <my_api_key>
+    },
+    body: JSON.stringify({
+      gpu_type: 'RTX_A6000_48GB',
+      ssh_key: 'my_ssh_key'
+    })
+  });
+```
+
+</CodeBlocks>
+
+You can see that instead of using `fetch` or a similar module to send an HTTP request and including the endpoint path and headers each time, the FluidStack TypeScript client simplifies the request for you. 
+
+## Call endpoints
+
+Requests to API endpoints are implemented in the SDK as methods of the client. For example, the [GET /instances](/api-reference/instances/list) endpoint is implemented like this:
+
+```ts Get the list of instances with the SDK
+client.instances.list()
+```
+
+In TypeScript/JavaScript, you must handle asynchronous operations such as HTTP requests explicitly using `async/await` or promises. To use `async/await`, wrap the method call in an `async` function and `await` the result, then call the function:
+
+```ts Use async/await to get the list of instances
+async function listInstances() {
+  const instances = await client.instances.list();
+}
+
+listInstances();
+```
+
+The code shown above does not do anything with the response from the endpoint. It is up to you to handle the response, including error handling.
+
+For example, you could simply print the entire response to the terminal:
+
+```ts Print the entire response
+async function listInstances() {
+  try {
+    const instances = await client.instances.list();
+    console.log(instances);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+}
+
+// Call the async function
+listInstances();
+```
+
+Or you could loop through the list and print only the name and status for each instance:
+
+```ts Print each instance name and status
+async function listInstances() {
+    const instances = await client.instances.list();
+    instances.forEach(instance => {
+        console.log(`Instance: ${instance.name}, Status: ${instance.status}`);
+    });
+}
+
+listInstances();
+```
+
+See [Programmatic Instance Management](/instances/manage/programmatic) for a more detailed tutorial on using TypeScript, Python, and their respective SDKs.
+
+## Instances 
+
+<Tabs>
+  <Tab title='List user instances'>
+
+```ts 
+  client.instances.list()
+```
+
+    **Parameters: None.**
+
+  </Tab>
+
+  <Tab title='Create an instance'>
+
+```ts 
+client.instances.create(
+  name='my_instance_name',
+  gpuType='RTX_A6000_48GB',
+  sshKey='my_ssh_key_name',
+  gpuCount=2,
+  operatingSystemLabel='ubuntu_20_04_lts_nvidia',
+  region='NORWAY'
+)
+```
+
+    | parameter              | type   | required | default                 |
+    |------------------------|--------|----------|-------------------------|
+    | gpuType                | string |     yes  |   n/a                   |
+    | sshKey                 | string |     yes  |   n/a                   |
+    | name                   | string |     no   |   randomized string     |
+    | gpuCount               | string |     no   |    1                    |
+    | operatingSystemLabel   | string |     no   | ubuntu_20_04_lts_nvidia |
+    | region                 | string |     no   | none                    |
+
+  </Tab>
+
+  <Tab title='Fetch an instance'>
+
+```ts 
+client.instances.get(
+    instanceId='instanceId')
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | instanceId             | string |     yes  |
+
+  </Tab>
+
+  <Tab title='Stop an instance'>
+
+```ts 
+client.instances.stop(
+    instanceId='instanceId',
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | instanceId             | string |     yes  |
+
+  </Tab>
+  
+  <Tab title='Start an instance'>
+
+```ts
+client.instances.start(
+    instanceId='instanceId',
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | instanceId             | string |     yes  |
+  </Tab>
+
+  <Tab title='Terminate an instance'>
+
+```ts 
+client.instances.delete(
+    instanceId='instanceId',
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | instanceId             | string |     yes  |
+  </Tab>
+
+</Tabs>
+
+## SSH Keys
+
+<Tabs>
+  <Tab title='List SSH keys'>
+
+```ts 
+  client.sshKeys.list()
+```
+
+    **Parameters: None.**
+  </Tab>
+
+  <Tab title='Add an SSH key'>
+
+```ts
+client.sshKeys.create(
+  name='mySSHKey', 
+  publicKey='myPublicKey' 
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | name                   | string |     yes  |
+    | publicKey              | string |     yes  |
+  </Tab>
+
+  <Tab title='Delete an SSH key'>
+
+```ts 
+client.sshKeys.delete(
+    sshKeyName='mySSHKey',
+)
+```
+
+    | parameter              | type   | required |
+    |------------------------|--------|----------|
+    | sshKeyName             | string |     yes  |
+
+  </Tab>
+</Tabs>
+
+## List available configurations and operating system templates
+
+<Tabs>
+  <Tab title='Configurations'>
+
+```ts 
+client.configurations.list()
+```
+
+    **Parameters: None.**
+
+  </Tab>
+
+  <Tab title='OS Templates'>
+
+```ts 
+client.templates.list()
+```
+
+    **Parameters: None.**
+
+  </Tab>
+</Tabs>

--- a/fern/docs/pages/ssh/use-ssh-keys.mdx
+++ b/fern/docs/pages/ssh/use-ssh-keys.mdx
@@ -6,7 +6,7 @@ You must provide an [SSH key](/ssh/what-is-ssh#about-ssh-keys) when you create a
 
 ## Generate a public/private key pair
 
-<Markdown src="../../snippets/public-key-formats.mdx" />
+<Markdown src='../../snippets/public-key-formats.mdx' />
 
 If you already have a public/private key pair of a supported format, you can use that pair instead of generating a new one.
 
@@ -17,7 +17,7 @@ Use any supported format for your key pair. The tabs below contain instructions 
 <Frame>
 <Tabs>
 
-  <Tab title="RSA">
+  <Tab title='RSA'>
     <Steps>
       ### Generate the key pair
       Enter the following command in your CLI shell:
@@ -43,7 +43,7 @@ cat ~/.ssh/id_rsa.pub
     </Steps>
   </Tab>
 
-  <Tab title="ECDSA with NIST curves">
+  <Tab title='ECDSA with NIST curves'>
     <Steps>
     ### Generate the key pair
     Enter the following command in your CLI shell:
@@ -85,30 +85,30 @@ cat ~/.ssh/id_ecdsa_256.pub
 
 Use your public key to create an SSH key on your FluidStack account. If you don't have a public key, see: [Generate a public/private key pair](#generate-a-publicprivate-key-pair).
 
-<Tip>In this context, "creating an SSH key" means "storing (adding) a copy of your public key on your FluidStack account." The stored SSH key is identical to your public key.</Tip>
+<Tip>In this context, 'creating an SSH key' means 'storing (adding) a copy of your public key on your FluidStack account.' The stored SSH key is identical to your public key.</Tip>
 
 <AccordionGroup>
 
-  <Accordion title="Use the FluidStack Dashboard">
-    <Markdown src="../../snippets/open-dashboard.mdx" />
-    <Markdown src="../../snippets/add-ssh-key-dashboard.mdx" />
+  <Accordion title='Use the FluidStack Dashboard'>
+    <Markdown src='../../snippets/open-dashboard.mdx' />
+    <Markdown src='../../snippets/add-ssh-key-dashboard.mdx' />
   </Accordion>
 
-  <Accordion title="Use the FluidStack API">
+  <Accordion title='Use the FluidStack API'>
     Create an SSH key by using the [Create an SSH key](/api-reference/ssh-keys/create) endpoint.
 
-    <EndpointRequestSnippet endpoint="POST /ssh_keys" />
+    <EndpointRequestSnippet endpoint='POST /ssh_keys' />
 
     <Tip>Make sure to replace the `<api-key>` value with your API key, the `<public-key>` value with your public key, and the `name` of `my_ssh_key` with the unique SSH key name you'd like to use.</Tip>
 
     If your POST request is successful, the endpoint responds with a JSON object that echoes the `name` and `public_key` that you sent:
 
-    ```json title="Response example"
-    {
-        "name": "my_ssh_key",
-        "public_key": "<your_public_key>"
-    }
-    ```
+```json title='Response example'
+{
+    "name": "my_ssh_key",
+    "public_key": "<your_public_key>"
+}
+```
   </Accordion>
   
 </AccordionGroup>
@@ -116,20 +116,20 @@ Use your public key to create an SSH key on your FluidStack account. If you don'
 ## View existing SSH keys
 
 <AccordionGroup>
-  <Accordion title="Use the FluidStack Dashboard">
-    <Markdown src="../../snippets/open-dashboard.mdx" />
+  <Accordion title='Use the FluidStack Dashboard'>
+    <Markdown src='../../snippets/open-dashboard.mdx' />
 
-    <Markdown src="../../snippets/view-ssh-keys-dashboard.mdx" />
+    <Markdown src='../../snippets/view-ssh-keys-dashboard.mdx' />
   </Accordion>
 
-  <Accordion title="Use the FluidStack API">
+  <Accordion title='Use the FluidStack API'>
     View SSH keys that have been added to your FluidStack account by using the [List SSH keys](/api-reference/ssh-keys/list) endpoint:
 
-    <EndpointRequestSnippet endpoint="GET /ssh_keys" />
+    <EndpointRequestSnippet endpoint='GET /ssh_keys' />
 
     If your GET request is successful, the endpoint responds with a JSON array of objects. Each object in the JSON array represents an SSH key, including its `name` and `public_key`: 
 
-```json title="Example response"
+```json title='Example response'
 [
     {
         "name": "my_ssh_key",
@@ -146,18 +146,18 @@ Use your public key to create an SSH key on your FluidStack account. If you don'
 
 ## Delete an SSH key
 
-<Markdown src="../../snippets/delete-ssh-key-warning.mdx" />
+<Markdown src='../../snippets/delete-ssh-key-warning.mdx' />
 <AccordionGroup>
-  <Accordion title="Use the FluidStack Dashboard">
-    <Markdown src="../../snippets/open-dashboard.mdx" />
-    <Markdown src="../../snippets/delete-ssh-key-dashboard.mdx" />
+  <Accordion title='Use the FluidStack Dashboard'>
+    <Markdown src='../../snippets/open-dashboard.mdx' />
+    <Markdown src='../../snippets/delete-ssh-key-dashboard.mdx' />
   </Accordion>
 
-  <Accordion title="Use the FluidStack API">
+  <Accordion title='Use the FluidStack API'>
 
     Delete an SSH key by using the [Delete an SSH key](/api-reference/ssh-keys/delete) endpoint. Replace the text `{ssh_key_name}` with the name of the key you want to delete:
 
-    <EndpointRequestSnippet endpoint="DELETE /ssh_keys/:ssh_key_name" />
+    <EndpointRequestSnippet endpoint='DELETE /ssh_keys/:ssh_key_name' />
 
   </Accordion>
 </AccordionGroup>
@@ -166,4 +166,4 @@ Use your public key to create an SSH key on your FluidStack account. If you don'
 
 Use your private key to authenticate when connecting to a running instance via SSH. The instance has an SSH key associated with it, provided when that instance was created. The private key must correspond to that SSH key.
 
-<Markdown src="../../snippets/connect-with-ssh.mdx" />
+<Markdown src='../../snippets/connect-with-ssh.mdx' />

--- a/fern/docs/pages/ssh/use-ssh-keys.mdx
+++ b/fern/docs/pages/ssh/use-ssh-keys.mdx
@@ -77,7 +77,7 @@ cat ~/.ssh/id_ecdsa_256.pub
 </Tabs>
 </Frame>
 
-<Warning>
+<Warning title="Warning">
   With any public/private key pair that you generate, your public key can be shared freely. Your private key should be just that—private! Take care not to share it with others, or in public repositories such as in GitHub. 
 </Warning>
 
@@ -85,7 +85,7 @@ cat ~/.ssh/id_ecdsa_256.pub
 
 Use your public key to create an SSH key on your FluidStack account. If you don't have a public key, see: [Generate a public/private key pair](#generate-a-publicprivate-key-pair).
 
-<Tip>In this context, 'creating an SSH key' means 'storing (adding) a copy of your public key on your FluidStack account.' The stored SSH key is identical to your public key.</Tip>
+<Tip title="Tip">In this context, 'creating an SSH key' means 'storing (adding) a copy of your public key on your FluidStack account.' The stored SSH key is identical to your public key.</Tip>
 
 <AccordionGroup>
 
@@ -99,7 +99,7 @@ Use your public key to create an SSH key on your FluidStack account. If you don'
 
     <EndpointRequestSnippet endpoint='POST /ssh_keys' />
 
-    <Tip>Make sure to replace the `<api-key>` value with your API key, the `<public-key>` value with your public key, and the `name` of `my_ssh_key` with the unique SSH key name you'd like to use.</Tip>
+    <Tip title="Tip">Make sure to replace the `<api-key>` value with your API key, the `<public-key>` value with your public key, and the `name` of `my_ssh_key` with the unique SSH key name you'd like to use.</Tip>
 
     If your POST request is successful, the endpoint responds with a JSON object that echoes the `name` and `public_key` that you sent:
 

--- a/fern/docs/pages/ssh/what-is-ssh.mdx
+++ b/fern/docs/pages/ssh/what-is-ssh.mdx
@@ -9,7 +9,7 @@ For improved security, we use [public-key cryptography](https://en.wikipedia.org
 
 Your public key is stored on your instance as your SSH key, when the instance is created. Its corresponding private key is stored locally on the computer that you use to access your instance. SSH access is granted by verifying that your private key corresponds to the public key. As an analogy, think of a public key as a lock that only your private key can unlock.
 
-<Tip>Public/private key pairs are used for many purposes, not only SSH. For example, they are used in file encryption, digital signatures, and cryptocurrency transactions.</Tip>
+<Tip title="Tip">Public/private key pairs are used for many purposes, not only SSH. For example, they are used in file encryption, digital signatures, and cryptocurrency transactions.</Tip>
 
 ## SSH clients
 

--- a/fern/docs/snippets/api-security-warning.mdx
+++ b/fern/docs/snippets/api-security-warning.mdx
@@ -1,3 +1,3 @@
-<Warning>
+<Warning title='Warning'>
   Avoid placing your API key in any file that might be shared with others. For information on using a `.env` file instead of adding the API key directly into a file, see: [API Overview - Secure use of your API key](/get-started/api-overview#secure-use-of-your-api-key).
 </Warning>

--- a/fern/docs/snippets/connect-with-ssh.mdx
+++ b/fern/docs/snippets/connect-with-ssh.mdx
@@ -1,13 +1,13 @@
-```bash title="Connect to your instance with SSH"
+```bash title='Connect to your instance with SSH'
 ssh -i <path_to_your_private_key> <username>@<ip_address>
 ```
 
 Examples:
 <CodeBlocks>
-```bash title="RSA"
+```bash title='RSA'
 ssh -i ~/.ssh/id_rsa ubuntu@192.0.2.0
 ```
-```bash title="ECDSA"
+```bash title='ECDSA'
 ssh -i ~/.ssh/id_ecdsa_256 ubuntu@192.0.2.0
 ```
 </CodeBlocks>

--- a/fern/docs/snippets/delete-ssh-key-warning.mdx
+++ b/fern/docs/snippets/delete-ssh-key-warning.mdx
@@ -1,3 +1,3 @@
-<Warning>
+<Warning title='Warning'>
   Deleting an SSH key removes the ability to authenticate to instances with that key.
 </Warning>

--- a/fern/docs/snippets/public-key-formats.mdx
+++ b/fern/docs/snippets/public-key-formats.mdx
@@ -1,4 +1,4 @@
-<Note>
+<Note title='Note'>
   We support OpenSSH public key formats: 
     - ssh-rsa
     - ssh-dss (DSA)


### PR DESCRIPTION
- Add information on using the TypeScript SDK
- Update Python SDK info to reflect new endpoint for fetching a single instance and to add the region parameter for instance creation
- Update 'Programmatic Instance Management' tutorial:
  - Include TypeScript scripts with and without SDK
  - Update Python scripts to use the new endpoint to fetch a single instance instead of looping through a list of instances to find it
  - Add deleting SSH key at the end of each script
  - Add a 'Cleanup' section 
- Add info on using dotenv module with TypeScript
- Minor formatting and consistency edits